### PR TITLE
Use newer version of `io-classes`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,8 +7,8 @@ packages: ./typed-protocols
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/io-sim
-  tag: f97c7206bd5ee8cce18f9971cfcfb02b1c6b7ebf
-  --sha256: 0552lryk9pjzr89kh5g6krn17dnymhklxm6656pgnh5vncy23p18
+  tag: b9824e8cab3429f0831e01dfc8f0fdecef1a2325
+  --sha256: 1p5f456d8gidsdxyhwp36r3jhhpizvvgphiv5mv2pgj2si40nklc
   subdir:
     io-sim
     io-classes

--- a/typed-protocols-examples/src/Network/TypedProtocol/Channel.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Channel.hs
@@ -18,8 +18,8 @@ module Network.TypedProtocol.Channel
   , loggingChannel
   ) where
 
+import           Control.Concurrent.Class.MonadSTM
 import           Control.Monad ((>=>))
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadTimer
 import qualified Data.ByteString as BS
@@ -243,9 +243,7 @@ channelEffect beforeSend afterRecv Channel{send, recv} =
 -- This is intended for testing, as a crude approximation of network delays.
 -- More accurate models along these lines are of course possible.
 --
-delayChannel :: ( MonadSTM m
-                , MonadTimer m
-                )
+delayChannel :: MonadTimer m
              => DiffTime
              -> Channel m a
              -> Channel m a

--- a/typed-protocols-examples/src/Network/TypedProtocol/Driver/Simple.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Driver/Simple.hs
@@ -38,7 +38,6 @@ import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Pipelined
 
 import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer (Tracer (..), contramap, traceWith)
 
@@ -138,7 +137,7 @@ runPeer tracer codec channel peer =
 --
 runPipelinedPeer
   :: forall ps (st :: ps) pr failure bytes m a.
-     (MonadSTM m, MonadAsync m, MonadThrow m, Exception failure)
+     (MonadAsync m, MonadThrow m, Exception failure)
   => Tracer m (TraceSendRecv ps)
   -> Codec ps failure m bytes
   -> Channel m bytes
@@ -181,7 +180,7 @@ data Role = Client | Server
 -- The first argument is expected to create two channels that are connected,
 -- for example 'createConnectedChannels'.
 --
-runConnectedPeers :: (MonadSTM m, MonadAsync m, MonadCatch m,
+runConnectedPeers :: (MonadAsync m, MonadCatch m,
                       Exception failure)
                   => m (Channel m bytes, Channel m bytes)
                   -> Tracer m (Role, TraceSendRecv ps)
@@ -199,7 +198,7 @@ runConnectedPeers createChannels tracer codec client server =
     tracerClient = contramap ((,) Client) tracer
     tracerServer = contramap ((,) Server) tracer
 
-runConnectedPeersPipelined :: (MonadSTM m, MonadAsync m, MonadCatch m,
+runConnectedPeersPipelined :: (MonadAsync m, MonadCatch m,
                                Exception failure)
                            => m (Channel m bytes, Channel m bytes)
                            -> Tracer m (PeerRole, TraceSendRecv ps)

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -26,6 +26,7 @@ import           Data.Void (Void)
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
 
+import           Control.Concurrent.Class.MonadSTM.TQueue
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM


### PR DESCRIPTION
There is a circular dependency between `io-sim` and `typed-protocols`.
