### PR TITLE
Fix index-state syntax in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,9 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: 2022-02-18T00:00:00Z
-index-state: cardano-haskell-packages 2022-11-07T00:00:00Z
+index-state:
+  , hackage.haskell.org 2022-02-18T00:00:00Z
+  , cardano-haskell-packages 2022-11-07T00:00:00Z
 
 packages: ./typed-protocols
           ./typed-protocols-cborg

--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2022-02-18T00:00:00Z
+  , hackage.haskell.org 2023-01-19T00:00:00Z
   , cardano-haskell-packages 2022-11-07T00:00:00Z
 
 packages: ./typed-protocols


### PR DESCRIPTION
The second `index-state` stanza completely ovverides the first, resetting hackage index state to HEAD.
See https://github.com/haskell/cabal/issues/8568