### PR TITLE
Use iog-contra-tracer instead of contra-tracer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,9 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2023-05-03T10:02:50Z
-  , cardano-haskell-packages 2023-04-24T15:33:00Z
+  , hackage.haskell.org 2023-05-04T00:55:55Z
+  , cardano-haskell-packages 2023-05-12T01:10:29Z
+
 
 packages: ./typed-protocols
           ./typed-protocols-cborg

--- a/typed-protocols-examples/typed-protocols-examples.cabal
+++ b/typed-protocols-examples/typed-protocols-examples.cabal
@@ -47,7 +47,7 @@ library
                      bytestring,
                      cborg,
                      serialise,
-                     contra-tracer,
+                     iog-contra-tracer,
                      io-classes,
                      si-timers,
                      time,
@@ -73,7 +73,7 @@ test-suite test
                    , Network.TypedProtocol.ReqResp.Tests
   build-depends:     base
                    , bytestring
-                   , contra-tracer
+                   , iog-contra-tracer
                    , typed-protocols
                    , typed-protocols-cborg
                    , typed-protocols-examples


### PR DESCRIPTION
There are two incompatible versions of the later, one on Hackage and one in CHaP. Switching to the former fixes this.