### PR TITLE
Better stateful API

### DIFF
--- a/typed-protocols-cborg/typed-protocols-cborg.cabal
+++ b/typed-protocols-cborg/typed-protocols-cborg.cabal
@@ -1,6 +1,6 @@
-cabal-version:       3.0
+cabal-version:       3.4
 name:                typed-protocols-cborg
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            CBOR codecs for typed-protocols
 -- description:
 license:             Apache-2.0
@@ -18,13 +18,13 @@ extra-source-files:  CHANGELOG.md, README.md
 library
   exposed-modules:   Network.TypedProtocol.Codec.CBOR
 
-  build-depends:     base            >=4.12  && <4.21,
-                     bytestring      >=0.10  && <0.13,
-                     cborg           >=0.2.1 && <0.3,
-                     singletons,       
+  build-depends:     base             >=4.12  && <4.21,
+                     bytestring       >=0.10  && <0.13,
+                     cborg            >=0.2.1 && <0.3,
+                     singletons,        
 
-                     io-classes     ^>=1.5,
-                     typed-protocols
+                     io-classes      ^>=1.5,
+                     typed-protocols ^>=0.3
 
   hs-source-dirs:    src
   default-language:  Haskell2010

--- a/typed-protocols-examples/src/Network/TypedProtocol/Stateful/ReqResp/Client.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Stateful/ReqResp/Client.hs
@@ -30,12 +30,12 @@ reqRespClientPeer
   -> Client (ReqResp req) StIdle State m a
 
 reqRespClientPeer (SendMsgDone a) =
-      Yield StateDone MsgDone (Done a)
+      Yield StateIdle StateDone MsgDone (Done a)
 
 reqRespClientPeer (SendMsgReq req next) =
-    Yield (StateBusy req)
+    Yield StateIdle (StateBusy req)
           (MsgReq req) $
-    Await $ \_ (MsgResp _ resp) ->
+    Await $ \_ (MsgResp resp) ->
       let client = next resp
       in ( Effect $ reqRespClientPeer <$> client
          , StateIdle

--- a/typed-protocols-examples/src/Network/TypedProtocol/Stateful/ReqResp/Server.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Stateful/ReqResp/Server.hs
@@ -30,7 +30,7 @@ reqRespServerPeer ReqRespServer { reqRespServerDone = a,
     MsgDone -> (Done a, StateDone)
     MsgReq req ->
       ( Effect $
-              (\(resp, k') -> Yield StateIdle (MsgResp req resp) (reqRespServerPeer  k'))
+              (\(resp, k') -> Yield (StateBusy req) StateIdle (MsgResp resp) (reqRespServerPeer  k'))
           <$> k req
       , StateBusy req
       )

--- a/typed-protocols-examples/src/Network/TypedProtocol/Stateful/ReqResp/Type.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Stateful/ReqResp/Type.hs
@@ -54,12 +54,7 @@ instance Protocol (ReqResp req) where
                         --   promoted to the state `StBusy` state.
             -> Message (ReqResp req) StIdle (StBusy resp)
     MsgResp :: Typeable resp
-            => req resp -- ^ request, not sent over the wire, just useful in the
-                        -- codec.
-                        --
-                        -- TODO: https://github.com/input-output-hk/typed-protocols/issues/59
-
-            -> resp     -- ^ respond
+            => resp     -- ^ respond
             -> Message (ReqResp req) (StBusy resp) StIdle
     MsgDone :: Message (ReqResp req) StIdle StDone
 

--- a/typed-protocols-examples/typed-protocols-examples.cabal
+++ b/typed-protocols-examples/typed-protocols-examples.cabal
@@ -1,6 +1,6 @@
-cabal-version:       3.0
+cabal-version:       3.4
 name:                typed-protocols-examples
-version:             0.4.0.0
+version:             0.5.0.0
 synopsis:            Examples and tests for the typed-protocols framework
 -- description:
 license:             Apache-2.0
@@ -63,7 +63,7 @@ library
                      si-timers,
                      network,
                      time,
-                     typed-protocols ^>= 0.2,
+                     typed-protocols ^>= 0.3,
                      typed-protocols-cborg,
                      typed-protocols-stateful
 

--- a/typed-protocols-stateful-cborg/src/Network/TypedProtocol/Stateful/Codec/CBOR.hs
+++ b/typed-protocols-stateful-cborg/src/Network/TypedProtocol/Stateful/Codec/CBOR.hs
@@ -48,7 +48,7 @@ mkCodecCborStrictBS
   => (forall (st :: ps) (st' :: ps).
              StateTokenI st
           =>ActiveState st
-          => f st' -> Message ps st st' -> CBOR.Encoding)
+          => f st -> Message ps st st' -> CBOR.Encoding)
   -- ^ cbor encoder
 
   -> (forall (st :: ps) s.
@@ -90,7 +90,7 @@ mkCodecCborLazyBS
   => (forall (st :: ps) (st' :: ps).
              StateTokenI st
           => ActiveState st
-          => f st'
+          => f st
           -> Message ps st st' -> CBOR.Encoding)
   -- ^ cbor encoder
 

--- a/typed-protocols-stateful-cborg/typed-protocols-stateful-cborg.cabal
+++ b/typed-protocols-stateful-cborg/typed-protocols-stateful-cborg.cabal
@@ -1,6 +1,6 @@
-cabal-version:       3.0
+cabal-version:       3.4
 name:                typed-protocols-stateful-cborg
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            CBOR codecs for typed-protocols
 -- description:
 license:             Apache-2.0
@@ -25,7 +25,7 @@ library
                      singletons,       
 
                      io-classes,
-                     typed-protocols,
+                     typed-protocols ^>= 0.3,
                      typed-protocols-cborg,
                      typed-protocols-stateful
 

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Codec.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Codec.hs
@@ -43,6 +43,7 @@ module Network.TypedProtocol.Stateful.Codec
     -- * Testing codec properties
   , AnyMessage (..)
   , pattern AnyMessageAndAgency
+  , showAnyMessage
   , prop_codecM
   , prop_codec
   , prop_codec_splitsM
@@ -68,7 +69,7 @@ data Codec ps failure (f :: ps -> Type) m bytes = Codec {
        encode :: forall (st :: ps) (st' :: ps).
                  StateTokenI st
               => ActiveState st
-              => f st'
+              => f st
               -> Message ps st st'
               -> bytes,
 
@@ -130,22 +131,30 @@ data AnyMessage ps (f :: ps -> Type) where
                 , ActiveState st
                 )
              => f st
-             -> f st'
              -> Message ps (st :: ps) (st' :: ps)
              -> AnyMessage ps f
 
-instance ( forall (st :: ps) (st' :: ps). Show (Message ps st st')
-         , forall (st :: ps). Show (f st)
-         )
-      => Show (AnyMessage ps f) where
-  show (AnyMessage st st' msg) = concat [ "AnyMessage "
-                                        , show st
-                                        , " "
-                                        , show st'
-                                        , " "
-                                        , show msg
-                                        ]
 
+-- | `showAnyMessage` is can be used to provide `Show` instance for
+-- `AnyMessage` if showing `Message` is independent of the state or one accepts
+-- showing only partial information included in message constructors or accepts
+-- message constructors to carry `Show` instances for its arguments.  Note that
+-- the proper solution is to define a custom `Show (AnyMessage ps f)` instance
+-- for a protocol `ps`, which give access to the state functor `f` in scope of
+-- `show`.
+--
+showAnyMessage :: forall ps f.
+                  ( forall st st'. Show (Message ps st st')
+                  , forall st. Show (f st)
+                  )
+               => AnyMessage ps f
+               -> String
+showAnyMessage (AnyMessage st msg) =
+    concat [ "AnyMessage "
+           , show st
+           , " "
+           , show msg
+           ]
 
 
 -- | A convenient pattern synonym which unwrap 'AnyMessage' giving both the
@@ -156,10 +165,9 @@ pattern AnyMessageAndAgency :: forall ps f. ()
                                (StateTokenI st, ActiveState st)
                             => StateToken st
                             -> f st
-                            -> f st'
                             -> Message ps st st'
                             -> AnyMessage ps f
-pattern AnyMessageAndAgency stateToken f f' msg <- AnyMessage f f' (getAgency -> (msg, stateToken))
+pattern AnyMessageAndAgency stateToken f msg <- AnyMessage f (getAgency -> (msg, stateToken))
   where
     AnyMessageAndAgency _ msg = AnyMessage msg
 {-# COMPLETE AnyMessageAndAgency #-}
@@ -175,22 +183,22 @@ getAgency msg = (msg, stateToken)
 prop_codecM
   :: forall ps failure f m bytes.
      ( Monad m
-     , Eq (TP.AnyMessage ps)
+     , Eq (AnyMessage ps f)
      )
   => Codec ps failure f m bytes
   -> AnyMessage ps f
   -> m Bool
-prop_codecM Codec {encode, decode} (AnyMessage f f' (msg :: Message ps st st')) = do
-    r <- decode (stateToken :: StateToken st) f >>= runDecoder [encode f' msg]
+prop_codecM Codec {encode, decode} a@(AnyMessage f (msg :: Message ps st st')) = do
+    r <- decode (stateToken :: StateToken st) f >>= runDecoder [encode f msg]
     case r :: Either failure (SomeMessage st) of
-      Right (SomeMessage msg') -> return $ TP.AnyMessage msg' == TP.AnyMessage msg
+      Right (SomeMessage msg') -> return $ AnyMessage f msg' == a
       Left _                   -> return False
 
 -- | The 'Codec' round-trip property in a pure monad.
 --
 prop_codec
   :: forall ps failure f m bytes.
-     (Monad m, Eq (TP.AnyMessage ps))
+     (Monad m, Eq (AnyMessage ps f))
   => (forall a. m a -> a)
   -> Codec ps failure f m bytes
   -> AnyMessage ps f
@@ -212,20 +220,20 @@ prop_codec runM codec msg =
 --
 prop_codec_splitsM
   :: forall ps failure f m bytes.
-     (Monad m, Eq (TP.AnyMessage ps))
+     (Monad m, Eq (AnyMessage ps f))
   => (bytes -> [[bytes]])   -- ^ alternative re-chunkings of serialised form
   -> Codec ps failure f m bytes
   -> AnyMessage ps f
   -> m Bool
 prop_codec_splitsM splits
-                   Codec {encode, decode} (AnyMessage f f' (msg :: Message ps st st')) = do
+                   Codec {encode, decode} a@(AnyMessage f (msg :: Message ps st st')) = do
     and <$> sequence
       [ do r <- decode (stateToken :: StateToken st) f >>= runDecoder bytes'
            case r :: Either failure (SomeMessage st) of
-             Right (SomeMessage msg') -> return $ TP.AnyMessage msg' == TP.AnyMessage msg
+             Right (SomeMessage msg') -> return $ AnyMessage f msg' == a
              Left _                   -> return False
 
-      | let bytes = encode f' msg
+      | let bytes = encode f msg
       , bytes' <- splits bytes ]
 
 
@@ -233,7 +241,7 @@ prop_codec_splitsM splits
 --
 prop_codec_splits
   :: forall ps failure f m bytes.
-     (Monad m, Eq (TP.AnyMessage ps))
+     (Monad m, Eq (AnyMessage ps f))
   => (bytes -> [[bytes]])
   -> (forall a. m a -> a)
   -> Codec ps failure f m bytes
@@ -250,7 +258,7 @@ prop_codec_splits splits runM codec msg =
 prop_codecs_compatM
   :: forall ps failure f m bytes.
      ( Monad m
-     , Eq (TP.AnyMessage ps)
+     , Eq (AnyMessage ps f)
      , forall a. Monoid a => Monoid (m a)
      )
   => Codec ps failure f m bytes
@@ -258,14 +266,14 @@ prop_codecs_compatM
   -> AnyMessage ps f
   -> m Bool
 prop_codecs_compatM codecA codecB
-                    (AnyMessage f f' (msg :: Message ps st st')) =
-    getAll <$> do r <- decode codecB (stateToken :: StateToken st) f >>= runDecoder [encode codecA f' msg]
+                    a@(AnyMessage f (msg :: Message ps st st')) =
+    getAll <$> do r <- decode codecB (stateToken :: StateToken st) f >>= runDecoder [encode codecA f msg]
                   case r :: Either failure (SomeMessage st) of
-                    Right (SomeMessage msg') -> return $ All $ TP.AnyMessage msg' == TP.AnyMessage msg
+                    Right (SomeMessage msg') -> return $ All $ AnyMessage f msg' == a
                     Left _                   -> return $ All False
-            <> do r <- decode codecA (stateToken :: StateToken st) f >>= runDecoder [encode codecB f' msg]
+            <> do r <- decode codecA (stateToken :: StateToken st) f >>= runDecoder [encode codecB f msg]
                   case r :: Either failure (SomeMessage st) of
-                    Right (SomeMessage msg') -> return $ All $ TP.AnyMessage msg' == TP.AnyMessage msg
+                    Right (SomeMessage msg') -> return $ All $ AnyMessage f msg' == a
                     Left _                   -> return $ All False
 
 -- | Like @'prop_codecs_compatM'@ but run in a pure monad @m@, e.g. @Identity@.
@@ -273,7 +281,7 @@ prop_codecs_compatM codecA codecB
 prop_codecs_compat
   :: forall ps failure f m bytes.
      ( Monad m
-     , Eq (TP.AnyMessage ps)
+     , Eq (AnyMessage ps f)
      , forall a. Monoid a => Monoid (m a)
      )
   => (forall a. m a -> a)

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Codec.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Codec.hs
@@ -41,8 +41,7 @@ module Network.TypedProtocol.Stateful.Codec
     -- * CodecFailure
   , CodecFailure (..)
     -- * Testing codec properties
-  , AnyMessage (..)
-  , pattern AnyMessageAndAgency
+  , AnyMessage (.., AnyMessageAndAgency)
   , showAnyMessage
   , prop_codecM
   , prop_codec
@@ -60,7 +59,7 @@ import           Network.TypedProtocol.Codec (CodecFailure (..),
                    DecodeStep (..),  SomeMessage (..), hoistDecodeStep,
                    isoDecodeStep, mapFailureDecodeStep, runDecoder,
                    runDecoderPure)
-import qualified Network.TypedProtocol.Codec as TP
+import qualified Network.TypedProtocol.Codec as TP hiding (AnyMessageAndAgency)
 
 
 -- | A stateful codec.

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Driver.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Driver.hs
@@ -41,7 +41,7 @@ data Driver ps (pr :: PeerRole) bytes failure dstate f m =
                         => ReflRelativeAgency (StateAgency st)
                                                WeHaveAgency
                                               (Relative pr (StateAgency st))
-                        -> f st'
+                        -> f st
                         -> Message ps st st'
                         -> m ()
 
@@ -92,9 +92,9 @@ runPeerWithDriver Driver{ sendMessage
 
     go !dstate  _ (Done _ x) = return (x, dstate)
 
-    go !dstate  _ (Yield refl !f msg k) = do
+    go !dstate  _ (Yield refl !f !f' msg k) = do
       sendMessage refl f msg
-      go dstate f k
+      go dstate f' k
 
     go !dstate !f (Await refl k) = do
       (SomeMessage msg, dstate') <- recvMessage refl f dstate

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Peer.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Peer.hs
@@ -112,8 +112,10 @@ data Peer ps pr st f m a where
        )
     => WeHaveAgencyProof pr st
     -- ^ agency singleton
+    -> f st
+    -- ^ initial protocol state
     -> f st'
-    -- ^ protocol state
+    -- ^ final protocol state
     -> Message ps st st'
     -- ^ protocol message
     -> Peer ps pr st' f m a

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Peer/Client.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Peer/Client.hs
@@ -54,13 +54,14 @@ pattern Yield :: forall ps st f m a.
                  , StateTokenI st'
                  , StateAgency st ~ ClientAgency
                  )
-              => f st'
+              => f st
+              -> f st'
               -> Message ps st st'
               -- ^ protocol message
               -> Client ps st' f m a
               -- ^ continuation
               -> Client ps st  f m a
-pattern Yield f msg k = TP.Yield ReflClientAgency f msg k
+pattern Yield f f' msg k = TP.Yield ReflClientAgency f f' msg k
 
 
 -- | Client role pattern for 'TP.Await'

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Peer/Server.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Peer/Server.hs
@@ -54,13 +54,14 @@ pattern Yield :: forall ps st f m a.
                  , StateTokenI st'
                  , StateAgency st ~ ServerAgency
                  )
-              => f st'
+              => f st
+              -> f st'
               -> Message ps st st'
               -- ^ protocol message
               -> Server ps st' f m a
               -- ^ continuation
               -> Server ps st  f m a
-pattern Yield f msg k = TP.Yield ReflServerAgency f msg k
+pattern Yield f f' msg k = TP.Yield ReflServerAgency f f' msg k
 
 
 -- | Server role pattern for 'TP.Await'

--- a/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Proofs.hs
+++ b/typed-protocols-stateful/src/Network/TypedProtocol/Stateful/Proofs.hs
@@ -62,7 +62,7 @@ removeState = go
       -> ST.Peer ps pr              st f m a
       ->    Peer ps pr NonPipelined st   m a
     go f (ST.Effect k) = Effect (go f <$> k)
-    go _ (ST.Yield refl f msg k) = Yield refl msg (go f k)
+    go _ (ST.Yield refl _f f' msg k) = Yield refl msg (go f' k)
     go f (ST.Await refl k) = Await refl $ \msg ->
       case k f msg of
         (k', f') -> go f' k'

--- a/typed-protocols-stateful/typed-protocols-stateful.cabal
+++ b/typed-protocols-stateful/typed-protocols-stateful.cabal
@@ -1,5 +1,6 @@
+cabal-version:       3.4
 name:                typed-protocols-stateful
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            A framework for strongly typed protocols
 -- description:
 license:             Apache-2.0
@@ -14,8 +15,6 @@ build-type:          Simple
 
 -- These should probably be added at some point.
 -- extra-source-files:  ChangeLog.md, README.md
-
-cabal-version:       >=1.10
 
 library
   exposed-modules:    Network.TypedProtocol.Stateful.Peer
@@ -38,7 +37,7 @@ library
                       contra-tracer,
                       singletons >= 3.0,
                       io-classes,
-                      typed-protocols
+                      typed-protocols ^>= 0.3
 
   hs-source-dirs:     src
   default-language:   Haskell2010

--- a/typed-protocols/src/Network/TypedProtocol/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Codec.hs
@@ -45,8 +45,7 @@ module Network.TypedProtocol.Codec
     -- * CodecFailure
   , CodecFailure (..)
     -- * Testing codec properties
-  , AnyMessage (..)
-  , pattern AnyMessageAndAgency
+  , AnyMessage (AnyMessage, AnyMessageAndAgency)
   , prop_codecM
   , prop_codec
   , prop_codec_splitsM

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -1,6 +1,6 @@
-cabal-version:       3.0
+cabal-version:       3.4
 name:                typed-protocols
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            A framework for strongly typed protocols
 -- description:
 license:             Apache-2.0


### PR DESCRIPTION
Fixes #59

- **typed-protocols-stateful: pass initial state through Yield**
- **typed-protocols-codec: changed how AnyMessageAndAgency is exported**
- **typed-protocols-0.3.0.0: bumped versions**
