### PR TITLE
Fix typed-protocols-doc

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,6 +19,6 @@ packages: ./typed-protocols
           ./typed-protocols-stateful
           ./typed-protocols-stateful-cborg
           ./typed-protocols-examples
-          -- ./typed-protocols-doc
+          ./typed-protocols-doc
 
 test-show-details: direct

--- a/cabal.project
+++ b/cabal.project
@@ -30,3 +30,7 @@ if impl (ghc >= 9.12)
     , cborg:ghc-prim
     , serialise:base
     , serialise:ghc-prim
+
+if(os(windows))
+  package text
+    flags: -simdutf

--- a/typed-protocols-doc/src/Network/TypedProtocol/Documentation/DefaultMain.hs
+++ b/typed-protocols-doc/src/Network/TypedProtocol/Documentation/DefaultMain.hs
@@ -65,8 +65,7 @@ pMainOptions =
           )
 
 
-defaultMain :: ( Codec codec
-               , HasInfo codec (DefEnumEncoding codec)
+defaultMain :: ( HasInfo codec (DefEnumEncoding codec)
                , HasInfo codec Word32
                ) => [ProtocolDescription codec] -> IO ()
 defaultMain descriptions = do
@@ -79,8 +78,7 @@ defaultMain descriptions = do
         render = getRenderer (moOutputFormat mainOptions) (moOutputFile mainOptions)
     write . render $ descriptions
 
-getRenderer :: ( Codec codec
-               , HasInfo codec (DefEnumEncoding codec)
+getRenderer :: ( HasInfo codec (DefEnumEncoding codec)
                , HasInfo codec Word32
                )
             => OutputFormat

--- a/typed-protocols-doc/test/Network/TypedProtocol/Tests/Documentation.hs
+++ b/typed-protocols-doc/test/Network/TypedProtocol/Tests/Documentation.hs
@@ -24,10 +24,10 @@ tests = testGroup "Documentation"
           , testProperty "state transitions" (p_correctStateTransitions testProtocolDescription)
           ]
 
-testProtocolDescription :: ProtocolDescription (TestCodec ())
-testProtocolDescription = $(describeProtocol ''ControlProtocol [''IO, ''()] ''TestCodec [''()])
+testProtocolDescription :: ProtocolDescription TestCodec
+testProtocolDescription = $(describeProtocol ''ControlProtocol [''IO, ''()] ''TestCodec [])
 
-p_correctAgencies :: ProtocolDescription (TestCodec ()) -> Property
+p_correctAgencies :: ProtocolDescription TestCodec -> Property
 p_correctAgencies d =
   counterexample (show stateAgencyMap) .
   once $
@@ -45,7 +45,7 @@ p_correctAgencies d =
   where
     stateAgencyMap = [(state, agency) | (state, _, agency) <- protocolStates d]
 
-p_correctStateTransitions :: ProtocolDescription (TestCodec ()) -> Property
+p_correctStateTransitions :: ProtocolDescription TestCodec -> Property
 p_correctStateTransitions d =
   once $
     checkMessage "VersionMessage" (State "InitialState") (State "IdleState")
@@ -83,6 +83,6 @@ p_correctStateTransitions d =
           counterexample "toState"
             (messageToState msg === toState)
 
-    findMessage :: String -> Maybe (MessageDescription (TestCodec ()))
+    findMessage :: String -> Maybe (MessageDescription TestCodec)
     findMessage msgName =
       listToMaybe [ msg | msg <- protocolMessages d, messageName msg == msgName ]

--- a/typed-protocols-doc/test/Network/TypedProtocol/Tests/TestProtocol.hs
+++ b/typed-protocols-doc/test/Network/TypedProtocol/Tests/TestProtocol.hs
@@ -23,7 +23,6 @@ import Control.Monad.Identity
 import Control.Monad.Except
 import Data.Proxy
 import Data.Word
-import Data.Typeable
 import Data.SerDoc.Class
 import Data.SerDoc.TH
 import Data.Text (Text)

--- a/typed-protocols-doc/test/Network/TypedProtocol/Tests/TestProtocolTH.hs
+++ b/typed-protocols-doc/test/Network/TypedProtocol/Tests/TestProtocolTH.hs
@@ -25,8 +25,8 @@ import qualified Data.Text.Lazy as LText
 import Text.Blaze.Html.Renderer.Text (renderHtml)
 import qualified Text.Blaze.Html.Renderer.Pretty as Pretty
 
-testProtocolDescription :: ProtocolDescription (TestCodec ())
-testProtocolDescription = $(describeProtocol ''TestProtocol [''()] ''TestCodec [''()])
+testProtocolDescription :: ProtocolDescription TestCodec
+testProtocolDescription = $(describeProtocol ''TestProtocol [] ''TestCodec [])
 
 testProtocolHtmlString :: String
 testProtocolHtmlString =

--- a/typed-protocols-examples/typed-protocols-examples.cabal
+++ b/typed-protocols-examples/typed-protocols-examples.cabal
@@ -64,10 +64,12 @@ library
                      time,
                      typed-protocols ^>= 0.4,
                      typed-protocols-cborg,
-                     typed-protocols-stateful
-
+                     typed-protocols-stateful,
   hs-source-dirs:    src
   default-language:  Haskell2010
+  -- ghc-9.2 pulls `ghc-heap-9.12` which is not compatible
+  if impl(ghc < 9.4)
+    build-depends: ghc-heap < 9.12
   ghc-options:       -Wall
                      -Wno-unticked-promoted-constructors
                      -Wcompat


### PR DESCRIPTION
This adapts typed-protocols-doc to work with the current typed-protocols API again.