### PR TITLE
Anti-pipelining (TODO better name) (AKA receiving despite having agency)

### DIFF
--- a/typed-protocols/examples/Network/TypedProtocol/Driver/Simple.hs
+++ b/typed-protocols/examples/Network/TypedProtocol/Driver/Simple.hs
@@ -15,9 +15,12 @@ module Network.TypedProtocol.Driver.Simple
   , Role (..)
     -- * Pipelined peers
   , runPipelinedPeer
+    -- * Anti-pipelined peers
+  , runAntiPipelinedPeer
     -- * Connected peers
   , runConnectedPeers
   , runConnectedPeersPipelined
+  , runConnectedPeersAntiPipelined
   , runConnectedPeersAsymmetric
     -- * Driver utilities
     -- | This may be useful if you want to write your own driver.
@@ -169,6 +172,33 @@ runPipelinedPeer tracer codec channel peer =
     driver = driverSimple tracer codec channel
 
 
+-- | Run an anti-pipelined peer with the given channel via the given codec.
+--
+-- This runs the peer to completion (if the protocol allows for termination).
+--
+-- Like pipelined peers, anti-pipelined peers rely on concurrency (the 'Sender'
+-- runs in parallel with the main peer), hence the 'MonadAsync' constraint.
+--
+runAntiPipelinedPeer
+  :: forall ps (st :: ps) pr failure bytes m a.
+     ( MonadAsync m
+     , MonadEvaluate m
+     , MonadThrow m
+     , Exception failure
+     , NFData failure
+     , NFData a
+     )
+  => Tracer m (TraceSendRecv ps)
+  -> Codec ps failure m bytes
+  -> Channel m bytes
+  -> PeerAntiPipelined ps pr st m a
+  -> m (a, Maybe bytes)
+runAntiPipelinedPeer tracer codec channel peer =
+    runAntiPipelinedPeerWithDriver driver peer
+  where
+    driver = driverSimple tracer codec channel
+
+
 --
 -- Utils
 --
@@ -250,6 +280,38 @@ runConnectedPeersPipelined createChannels tracer codec client server =
     (fst <$> runPipelinedPeer tracerClient codec clientChannel client)
       `concurrently`
     (fst <$> runPeer          tracerServer codec serverChannel server)
+  where
+    tracerClient = contramap ((,) AsClient) tracer
+    tracerServer = contramap ((,) AsServer) tracer
+
+
+-- | Run a pipelined client against an anti-pipelined server via a pair of
+-- connected 'Channel's and a common 'Codec'. Both peers rely on concurrency:
+-- the client's receivers and the server's 'Sender' each run in parallel with
+-- their main thread, so this is where the interleavings anti-pipelining is
+-- meant to exploit actually occur (unlike @connect@, which forgets them).
+--
+runConnectedPeersAntiPipelined
+  :: ( MonadAsync m
+     , MonadCatch m
+     , MonadEvaluate m
+     , Exception failure
+     , NFData failure
+     , NFData a
+     , NFData b
+     )
+  => m (Channel m bytes, Channel m bytes)
+  -> Tracer m (PeerRole, TraceSendRecv ps)
+  -> Codec ps failure m bytes
+  -> PeerPipelined     ps             pr  st m a
+  -> PeerAntiPipelined ps (FlipAgency pr) st m b
+  -> m (a, b)
+runConnectedPeersAntiPipelined createChannels tracer codec client server =
+    createChannels >>= \(clientChannel, serverChannel) ->
+
+    (fst <$> runPipelinedPeer     tracerClient codec clientChannel client)
+      `concurrently`
+    (fst <$> runAntiPipelinedPeer tracerServer codec serverChannel server)
   where
     tracerClient = contramap ((,) AsClient) tracer
     tracerServer = contramap ((,) AsServer) tracer

--- a/typed-protocols/examples/Network/TypedProtocol/Driver/Simple.hs
+++ b/typed-protocols/examples/Network/TypedProtocol/Driver/Simple.hs
@@ -16,11 +16,11 @@ module Network.TypedProtocol.Driver.Simple
     -- * Pipelined peers
   , runPipelinedPeer
     -- * Dual-pipelined peers
-  , runDualPipelinedPeer
+  , runDualPipelined1Peer
     -- * Connected peers
   , runConnectedPeers
   , runConnectedPeersPipelined
-  , runConnectedPeersDualPipelined
+  , runConnectedPeersDualPipelined1
   , runConnectedPeersAsymmetric
     -- * Driver utilities
     -- | This may be useful if you want to write your own driver.
@@ -179,7 +179,7 @@ runPipelinedPeer tracer codec channel peer =
 -- Like pipelined peers, anti-pipelined peers rely on concurrency (the 'Sender'
 -- runs in parallel with the main peer), hence the 'MonadAsync' constraint.
 --
-runDualPipelinedPeer
+runDualPipelined1Peer
   :: forall ps (st :: ps) pr failure bytes m a.
      ( MonadAsync m
      , MonadEvaluate m
@@ -191,10 +191,10 @@ runDualPipelinedPeer
   => Tracer m (TraceSendRecv ps)
   -> Codec ps failure m bytes
   -> Channel m bytes
-  -> PeerDualPipelined ps pr st m a
+  -> PeerDualPipelined1 ps pr st m a
   -> m (a, Maybe bytes)
-runDualPipelinedPeer tracer codec channel peer =
-    runDualPipelinedPeerWithDriver driver peer
+runDualPipelined1Peer tracer codec channel peer =
+    runDualPipelined1PeerWithDriver driver peer
   where
     driver = driverSimple tracer codec channel
 
@@ -291,7 +291,7 @@ runConnectedPeersPipelined createChannels tracer codec client server =
 -- their main thread, so this is where the interleavings anti-pipelining is
 -- meant to exploit actually occur (unlike @connect@, which forgets them).
 --
-runConnectedPeersDualPipelined
+runConnectedPeersDualPipelined1
   :: ( MonadAsync m
      , MonadCatch m
      , MonadEvaluate m
@@ -304,14 +304,14 @@ runConnectedPeersDualPipelined
   -> Tracer m (PeerRole, TraceSendRecv ps)
   -> Codec ps failure m bytes
   -> PeerPipelined     ps             pr  st m a
-  -> PeerDualPipelined ps (FlipAgency pr) st m b
+  -> PeerDualPipelined1 ps (FlipAgency pr) st m b
   -> m (a, b)
-runConnectedPeersDualPipelined createChannels tracer codec client server =
+runConnectedPeersDualPipelined1 createChannels tracer codec client server =
     createChannels >>= \(clientChannel, serverChannel) ->
 
     (fst <$> runPipelinedPeer     tracerClient codec clientChannel client)
       `concurrently`
-    (fst <$> runDualPipelinedPeer tracerServer codec serverChannel server)
+    (fst <$> runDualPipelined1Peer tracerServer codec serverChannel server)
   where
     tracerClient = contramap ((,) AsClient) tracer
     tracerServer = contramap ((,) AsServer) tracer

--- a/typed-protocols/examples/Network/TypedProtocol/Driver/Simple.hs
+++ b/typed-protocols/examples/Network/TypedProtocol/Driver/Simple.hs
@@ -15,12 +15,12 @@ module Network.TypedProtocol.Driver.Simple
   , Role (..)
     -- * Pipelined peers
   , runPipelinedPeer
-    -- * Anti-pipelined peers
-  , runAntiPipelinedPeer
+    -- * Dual-pipelined peers
+  , runDualPipelinedPeer
     -- * Connected peers
   , runConnectedPeers
   , runConnectedPeersPipelined
-  , runConnectedPeersAntiPipelined
+  , runConnectedPeersDualPipelined
   , runConnectedPeersAsymmetric
     -- * Driver utilities
     -- | This may be useful if you want to write your own driver.
@@ -179,7 +179,7 @@ runPipelinedPeer tracer codec channel peer =
 -- Like pipelined peers, anti-pipelined peers rely on concurrency (the 'Sender'
 -- runs in parallel with the main peer), hence the 'MonadAsync' constraint.
 --
-runAntiPipelinedPeer
+runDualPipelinedPeer
   :: forall ps (st :: ps) pr failure bytes m a.
      ( MonadAsync m
      , MonadEvaluate m
@@ -191,10 +191,10 @@ runAntiPipelinedPeer
   => Tracer m (TraceSendRecv ps)
   -> Codec ps failure m bytes
   -> Channel m bytes
-  -> PeerAntiPipelined ps pr st m a
+  -> PeerDualPipelined ps pr st m a
   -> m (a, Maybe bytes)
-runAntiPipelinedPeer tracer codec channel peer =
-    runAntiPipelinedPeerWithDriver driver peer
+runDualPipelinedPeer tracer codec channel peer =
+    runDualPipelinedPeerWithDriver driver peer
   where
     driver = driverSimple tracer codec channel
 
@@ -291,7 +291,7 @@ runConnectedPeersPipelined createChannels tracer codec client server =
 -- their main thread, so this is where the interleavings anti-pipelining is
 -- meant to exploit actually occur (unlike @connect@, which forgets them).
 --
-runConnectedPeersAntiPipelined
+runConnectedPeersDualPipelined
   :: ( MonadAsync m
      , MonadCatch m
      , MonadEvaluate m
@@ -304,14 +304,14 @@ runConnectedPeersAntiPipelined
   -> Tracer m (PeerRole, TraceSendRecv ps)
   -> Codec ps failure m bytes
   -> PeerPipelined     ps             pr  st m a
-  -> PeerAntiPipelined ps (FlipAgency pr) st m b
+  -> PeerDualPipelined ps (FlipAgency pr) st m b
   -> m (a, b)
-runConnectedPeersAntiPipelined createChannels tracer codec client server =
+runConnectedPeersDualPipelined createChannels tracer codec client server =
     createChannels >>= \(clientChannel, serverChannel) ->
 
     (fst <$> runPipelinedPeer     tracerClient codec clientChannel client)
       `concurrently`
-    (fst <$> runAntiPipelinedPeer tracerServer codec serverChannel server)
+    (fst <$> runDualPipelinedPeer tracerServer codec serverChannel server)
   where
     tracerClient = contramap ((,) AsClient) tracer
     tracerServer = contramap ((,) AsServer) tracer

--- a/typed-protocols/examples/Network/TypedProtocol/ReqResp/Server.hs
+++ b/typed-protocols/examples/Network/TypedProtocol/ReqResp/Server.hs
@@ -58,13 +58,13 @@ reqRespServerPeer ReqRespServer{..} =
 -- environment's choice — either to collect an outstanding reply or keep
 -- receiving.
 --
-reqRespServerPeerAntiPipelined
+reqRespServerPeerDualPipelined
   :: forall resp m. Functor m
   => m resp
   -- ^ produce (and record) the next reply
-  -> ServerAntiPipelined (ReqResp () resp) StIdle m ()
-reqRespServerPeerAntiPipelined nextResp =
-    ServerAntiPipelined sender (go Zero)
+  -> ServerDualPipelined (ReqResp () resp) StIdle m ()
+reqRespServerPeerDualPipelined nextResp =
+    ServerDualPipelined sender (go Zero)
   where
     sender :: Sender (ReqResp () resp) StBusy StIdle m
     sender = SenderEffect $
@@ -74,19 +74,19 @@ reqRespServerPeerAntiPipelined nextResp =
     -- but stay willing to receive ahead
     go :: forall n.
           Nat n
-       -> Server (ReqResp () resp) (AntiPipelined StBusy StIdle n) StIdle m ()
+       -> Server (ReqResp () resp) (DualPipelined StBusy StIdle n) StIdle m ()
     go  Zero     = await Zero
-    go (Succ n') = AntiCollect (await n') (Just (await (Succ n')))
+    go (Succ n') = DualCollect (await n') (Just (await (Succ n')))
 
     await :: forall n.
              Nat n
-          -> Server (ReqResp () resp) (AntiPipelined StBusy StIdle n) StIdle m ()
+          -> Server (ReqResp () resp) (DualPipelined StBusy StIdle n) StIdle m ()
     await n = Await $ \msg -> case msg of
-                MsgReq _ -> YieldAntiPipelined (go (Succ n))
+                MsgReq _ -> YieldDualPipelined (go (Succ n))
                 MsgDone  -> drain n
 
     drain :: forall n.
              Nat n
-          -> Server (ReqResp () resp) (AntiPipelined StBusy StIdle n) StDone m ()
+          -> Server (ReqResp () resp) (DualPipelined StBusy StIdle n) StDone m ()
     drain  Zero     = Done ()
-    drain (Succ n') = AntiCollect (drain n') Nothing
+    drain (Succ n') = DualCollect (drain n') Nothing

--- a/typed-protocols/examples/Network/TypedProtocol/ReqResp/Server.hs
+++ b/typed-protocols/examples/Network/TypedProtocol/ReqResp/Server.hs
@@ -45,3 +45,48 @@ reqRespServerPeer ReqRespServer{..} =
       MsgReq req -> Effect $ do
         (resp, next) <- recvMsgReq req
         pure $ Yield (MsgResp resp) (reqRespServerPeer next)
+
+
+-- | An anti-pipelined 'ReqResp' server.
+--
+-- The single 'Sender' takes no argument, so a reply can depend on its request
+-- only indirectly — by the peer stashing request-derived data into state (via
+-- an 'Effect') for the 'Sender' to read. This example doesn't do that: it
+-- ignores the request payload (hence @()@) and draws each reply from the
+-- supplied action, which typically reads and advances some state. It receives
+-- ahead, delegating every reply to the 'Sender', and is willing — at the
+-- environment's choice — either to collect an outstanding reply or keep
+-- receiving.
+--
+reqRespServerPeerAntiPipelined
+  :: forall resp m. Functor m
+  => m resp
+  -- ^ produce (and record) the next reply
+  -> ServerAntiPipelined (ReqResp () resp) StIdle m ()
+reqRespServerPeerAntiPipelined nextResp =
+    ServerAntiPipelined sender (go Zero)
+  where
+    sender :: Sender (ReqResp () resp) StBusy StIdle m
+    sender = SenderEffect $
+      (\resp -> SenderYield (MsgResp resp) SenderDone) <$> nextResp
+
+    -- with @n@ replies outstanding: collect one if the environment chooses,
+    -- but stay willing to receive ahead
+    go :: forall n.
+          Nat n
+       -> Server (ReqResp () resp) (AntiPipelined StBusy StIdle n) StIdle m ()
+    go  Zero     = await Zero
+    go (Succ n') = AntiCollect (await n') (Just (await (Succ n')))
+
+    await :: forall n.
+             Nat n
+          -> Server (ReqResp () resp) (AntiPipelined StBusy StIdle n) StIdle m ()
+    await n = Await $ \msg -> case msg of
+                MsgReq _ -> YieldAntiPipelined (go (Succ n))
+                MsgDone  -> drain n
+
+    drain :: forall n.
+             Nat n
+          -> Server (ReqResp () resp) (AntiPipelined StBusy StIdle n) StDone m ()
+    drain  Zero     = Done ()
+    drain (Succ n') = AntiCollect (drain n') Nothing

--- a/typed-protocols/examples/Network/TypedProtocol/ReqResp/Server.hs
+++ b/typed-protocols/examples/Network/TypedProtocol/ReqResp/Server.hs
@@ -58,13 +58,13 @@ reqRespServerPeer ReqRespServer{..} =
 -- environment's choice — either to collect an outstanding reply or keep
 -- receiving.
 --
-reqRespServerPeerDualPipelined
+reqRespServerPeerDualPipelined1
   :: forall resp m. Functor m
   => m resp
   -- ^ produce (and record) the next reply
-  -> ServerDualPipelined (ReqResp () resp) StIdle m ()
-reqRespServerPeerDualPipelined nextResp =
-    ServerDualPipelined sender (go Zero)
+  -> ServerDualPipelined1 (ReqResp () resp) StIdle m ()
+reqRespServerPeerDualPipelined1 nextResp =
+    ServerDualPipelined1 sender (go Zero)
   where
     sender :: Sender (ReqResp () resp) StBusy StIdle m
     sender = SenderEffect $
@@ -74,19 +74,19 @@ reqRespServerPeerDualPipelined nextResp =
     -- but stay willing to receive ahead
     go :: forall n.
           Nat n
-       -> Server (ReqResp () resp) (DualPipelined StBusy StIdle n) StIdle m ()
+       -> Server (ReqResp () resp) (DualPipelined1 StBusy StIdle n) StIdle m ()
     go  Zero     = await Zero
-    go (Succ n') = DualCollect (await n') (Just (await (Succ n')))
+    go (Succ n') = DualCollect1 (await n') (Just (await (Succ n')))
 
     await :: forall n.
              Nat n
-          -> Server (ReqResp () resp) (DualPipelined StBusy StIdle n) StIdle m ()
+          -> Server (ReqResp () resp) (DualPipelined1 StBusy StIdle n) StIdle m ()
     await n = Await $ \msg -> case msg of
-                MsgReq _ -> YieldDualPipelined (go (Succ n))
+                MsgReq _ -> YieldDualPipelined1 (go (Succ n))
                 MsgDone  -> drain n
 
     drain :: forall n.
              Nat n
-          -> Server (ReqResp () resp) (DualPipelined StBusy StIdle n) StDone m ()
+          -> Server (ReqResp () resp) (DualPipelined1 StBusy StIdle n) StDone m ()
     drain  Zero     = Done ()
-    drain (Succ n') = DualCollect (drain n') Nothing
+    drain (Succ n') = DualCollect1 (drain n') Nothing

--- a/typed-protocols/src/Network/TypedProtocol/Core.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Core.hs
@@ -492,17 +492,17 @@ data N = Z | S N
 -- | Promoted data type which indicates if 'Peer' is used in
 -- pipelined mode or not.
 --
-data IsPipelined where
+data IsPipelined ps where
     -- | Pipelined peer which is using `c :: Type` for collecting responses
     -- from a pipelined messages. 'N' indicates depth of pipelining.
-    Pipelined    :: N -> Type -> IsPipelined
+    Pipelined     :: N -> Type -> IsPipelined ps
 
     -- | Non-pipelined peer.
-    NonPipelined :: IsPipelined
+    NonPipelined  :: IsPipelined ps
 
-    -- | Pipelined peer for a /server/ that only ever receives one
-    -- possible request.
-    AntiPipelined    :: N -> IsPipelined
+    -- | Pipelined peer for a /server/ that only ever uses one
+    -- 'Network.TypedProtocol.Peer.Sender'
+    AntiPipelined :: ps -> ps -> N -> IsPipelined ps
 
 -- | Type level count of the number of outstanding pipelined yields for which
 -- we have not yet collected a receiver result. Used to
@@ -511,17 +511,17 @@ data IsPipelined where
 -- and to ensure that the non-pipelined primitives 'Yield', 'Await' and 'Done'
 -- are only used when there are none unsatisfied pipelined requests.
 --
-type        Outstanding :: IsPipelined -> N
+type        Outstanding :: IsPipelined ps -> N
 type family Outstanding pl where
-  Outstanding 'NonPipelined      = Z
-  Outstanding ('Pipelined n _)   = n
-  Outstanding ('AntiPipelined _) = Z
+  Outstanding 'NonPipelined          = Z
+  Outstanding ('Pipelined n _)       = n
+  Outstanding ('AntiPipelined _ _ _) = Z
 
-type        AntiOutstanding :: IsPipelined -> N
+type        AntiOutstanding :: IsPipelined ps -> N
 type family AntiOutstanding pl where
-  AntiOutstanding 'NonPipelined      = Z
-  AntiOutstanding ('Pipelined _ _)   = Z
-  AntiOutstanding ('AntiPipelined n) = n
+  AntiOutstanding 'NonPipelined          = Z
+  AntiOutstanding ('Pipelined _ _)       = Z
+  AntiOutstanding ('AntiPipelined _ _ n) = n
 
 -- | A value level inductive natural number, indexed by the corresponding type
 -- level natural number 'N'.

--- a/typed-protocols/src/Network/TypedProtocol/Core.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Core.hs
@@ -44,7 +44,7 @@ module Network.TypedProtocol.Core
   , IsPipelined (..)
     -- *** Outstanding
   , Outstanding
-  , AntiOutstanding
+  , DualOutstanding
     -- *** N and Nat
   , N (..)
   , Nat (Succ, Zero)
@@ -502,7 +502,7 @@ data IsPipelined ps where
 
     -- | Pipelined peer for a /server/ that only ever uses one
     -- 'Network.TypedProtocol.Peer.Sender'
-    AntiPipelined :: ps -> ps -> N -> IsPipelined ps
+    DualPipelined :: ps -> ps -> N -> IsPipelined ps
 
 -- | Type level count of the number of outstanding pipelined yields for which
 -- we have not yet collected a receiver result. Used to
@@ -515,13 +515,13 @@ type        Outstanding :: IsPipelined ps -> N
 type family Outstanding pl where
   Outstanding 'NonPipelined          = Z
   Outstanding ('Pipelined n _)       = n
-  Outstanding ('AntiPipelined _ _ _) = Z
+  Outstanding ('DualPipelined _ _ _) = Z
 
-type        AntiOutstanding :: IsPipelined ps -> N
-type family AntiOutstanding pl where
-  AntiOutstanding 'NonPipelined          = Z
-  AntiOutstanding ('Pipelined _ _)       = Z
-  AntiOutstanding ('AntiPipelined _ _ n) = n
+type        DualOutstanding :: IsPipelined ps -> N
+type family DualOutstanding pl where
+  DualOutstanding 'NonPipelined          = Z
+  DualOutstanding ('Pipelined _ _)       = Z
+  DualOutstanding ('DualPipelined _ _ n) = n
 
 -- | A value level inductive natural number, indexed by the corresponding type
 -- level natural number 'N'.

--- a/typed-protocols/src/Network/TypedProtocol/Core.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Core.hs
@@ -501,8 +501,8 @@ data IsPipelined ps where
     NonPipelined  :: IsPipelined ps
 
     -- | Pipelined peer for a /server/ that only ever uses one
-    -- 'Network.TypedProtocol.Peer.Sender'
-    DualPipelined :: ps -> ps -> N -> IsPipelined ps
+    -- 'Network.TypedProtocol.Peer.Sender' (hence the @1@ suffix)
+    DualPipelined1 :: ps -> ps -> N -> IsPipelined ps
 
 -- | Type level count of the number of outstanding pipelined yields for which
 -- we have not yet collected a receiver result. Used to
@@ -515,13 +515,13 @@ type        Outstanding :: IsPipelined ps -> N
 type family Outstanding pl where
   Outstanding 'NonPipelined          = Z
   Outstanding ('Pipelined n _)       = n
-  Outstanding ('DualPipelined _ _ _) = Z
+  Outstanding ('DualPipelined1 _ _ _) = Z
 
 type        DualOutstanding :: IsPipelined ps -> N
 type family DualOutstanding pl where
   DualOutstanding 'NonPipelined          = Z
   DualOutstanding ('Pipelined _ _)       = Z
-  DualOutstanding ('DualPipelined _ _ n) = n
+  DualOutstanding ('DualPipelined1 _ _ n) = n
 
 -- | A value level inductive natural number, indexed by the corresponding type
 -- level natural number 'N'.

--- a/typed-protocols/src/Network/TypedProtocol/Core.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Core.hs
@@ -44,6 +44,7 @@ module Network.TypedProtocol.Core
   , IsPipelined (..)
     -- *** Outstanding
   , Outstanding
+  , AntiOutstanding
     -- *** N and Nat
   , N (..)
   , Nat (Succ, Zero)
@@ -499,6 +500,10 @@ data IsPipelined where
     -- | Non-pipelined peer.
     NonPipelined :: IsPipelined
 
+    -- | Pipelined peer for a /server/ that only ever receives one
+    -- possible request.
+    AntiPipelined    :: N -> IsPipelined
+
 -- | Type level count of the number of outstanding pipelined yields for which
 -- we have not yet collected a receiver result. Used to
 -- ensure that 'Collect' is only used when there are outstanding results to
@@ -508,8 +513,15 @@ data IsPipelined where
 --
 type        Outstanding :: IsPipelined -> N
 type family Outstanding pl where
-  Outstanding 'NonPipelined    = Z
-  Outstanding ('Pipelined n _) = n
+  Outstanding 'NonPipelined      = Z
+  Outstanding ('Pipelined n _)   = n
+  Outstanding ('AntiPipelined _) = Z
+
+type        AntiOutstanding :: IsPipelined -> N
+type family AntiOutstanding pl where
+  AntiOutstanding 'NonPipelined      = Z
+  AntiOutstanding ('Pipelined _ _)   = Z
+  AntiOutstanding ('AntiPipelined n) = n
 
 -- | A value level inductive natural number, indexed by the corresponding type
 -- level natural number 'N'.

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -453,7 +453,7 @@ runAntiPipelinedPeerMain sendVar doneVar
       (SomeMessage msg, dstate') <- recvMessage refl dstate
       go dstate' (k msg)
 
-    go dstate (YieldAntiPipelined _refl k) = do
+    go dstate (YieldAntiPipelined k) = do
       atomically $ modifyTVar' sendVar (+ 1)
       go dstate k
 
@@ -488,8 +488,8 @@ runAntiPipelinedPeerSender sender sendVar doneVar
   where
     runSender :: forall stA stZ. Sender ps pr stA stZ m -> m ()
     runSender = \case
-      SenderEffect k         -> k >>= runSender
-      SenderDone             -> return ()
-      SenderYield refl msg k -> do
+      SenderEffect k          -> k >>= runSender
+      SenderDone              -> return ()
+      SenderYield  refl msg k -> do
         sendMessage refl msg
         runSender k

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -13,14 +13,19 @@ module Network.TypedProtocol.Driver
   , runPeerWithDriver
     -- * Pipelined peers
   , runPipelinedPeerWithDriver
+    -- * Anti-pipelined peers
+  , runAntiPipelinedPeerWithDriver
   ) where
 
+import Control.Monad (forever, join)
 import Data.Void (Void)
+import Numeric.Natural (Natural)
 
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.Peer
 
 import Control.Concurrent.Class.MonadSTM.TQueue
+import Control.Concurrent.Class.MonadSTM.TVar
 import Control.DeepSeq (NFData, force)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadFork
@@ -363,3 +368,132 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
     go dstate (ReceiverAwait refl k) = do
       (SomeMessage msg, dstate') <- recvMessage refl dstate
       go dstate' (k msg)
+
+
+--
+-- Running anti-pipelined peers
+--
+
+-- | An existential wrapper for a queued 'Sender', so that the sender thread's
+-- queue can hold senders regardless of their (from\/to) state indices.
+--
+data SomeSender ps pr m where
+     SomeSender :: Sender ps pr st stdone m -> SomeSender ps pr m
+
+-- | Run an anti-pipelined peer with the given driver.
+--
+-- Dual to 'runPipelinedPeerWithDriver': where a pipelined peer sends ahead and
+-- defers its receives to a parallel receiver thread, an anti-pipelined peer
+-- receives ahead and defers its sends to a parallel sender thread.
+--
+-- Unlike the pipelined driver, there is no trailing-data handoff: the peer
+-- thread performs every 'recvMessage' (so it owns @dstate@ outright), and the
+-- sender thread performs every 'sendMessage'. The two only ever touch opposite
+-- directions of the channel, and the 'AntiOutstanding' index guarantees that
+-- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
+-- thread is idle.
+--
+runAntiPipelinedPeerWithDriver
+  :: forall ps (st :: ps) pr dstate m a.
+     ( MonadAsync m
+     , MonadEvaluate m
+     , NFData a
+     )
+  => Driver ps pr dstate m
+  -> PeerAntiPipelined ps pr st m a
+  -> m (a, dstate)
+runAntiPipelinedPeerWithDriver driver@Driver{initialDState} (PeerAntiPipelined peer) = do
+    sendQueue <- atomically newTQueue
+    doneVar   <- newTVarIO 0
+    r@(a, _dstate) <- runAntiPipelinedPeerSenderQueue sendQueue doneVar driver
+           `withAsyncLoop`
+         runAntiPipelinedPeerMain       sendQueue doneVar driver peer initialDState
+
+    _ <- evaluate (force a)
+    return r
+
+  where
+    withAsyncLoop :: m Void -> m x -> m x
+    withAsyncLoop left right = do
+      -- race will throw if either of the threads throw
+      res <- race left right
+      case res of
+        Left v  -> case v of {}
+        Right a -> return a
+
+
+runAntiPipelinedPeerMain
+  :: forall ps (st :: ps) pr dstate m a.
+     ( MonadSTM    m
+     , MonadThread m
+     )
+  => TQueue m (SomeSender ps pr m)
+  -> TVar m Natural
+  -> Driver ps pr dstate m
+  -> Peer ps pr ('AntiPipelined Z) st m a
+  -> dstate
+  -> m (a, dstate)
+runAntiPipelinedPeerMain sendQueue doneVar
+                         Driver{sendMessage, recvMessage}
+                         peer0 dstate0 = do
+    threadId <- myThreadId
+    labelThread threadId "antipipelined-peer-main"
+    go dstate0 peer0
+  where
+    go :: forall st' n.
+          dstate
+       -> Peer ps pr ('AntiPipelined n) st' m a
+       -> m (a, dstate)
+    go dstate (Effect k) = k >>= go dstate
+    go dstate (Done _ x) = return (x, dstate)
+
+    -- Only reachable at 'AntiPipelined Z' (the constructor demands
+    -- @AntiOutstanding ~ Z@), i.e. when the sender thread is provably idle.
+    go dstate (Yield refl msg k) = do
+      sendMessage refl msg
+      go dstate k
+
+    -- Legal at any 'AntiOutstanding': receiving ahead is the whole point.
+    go dstate (Await refl k) = do
+      (SomeMessage msg, dstate') <- recvMessage refl dstate
+      go dstate' (k msg)
+
+    go dstate (YieldAntiPipelined _refl sender k) = do
+      atomically (writeTQueue sendQueue (SomeSender sender))
+      go dstate k
+
+    go dstate (AntiCollect k mbNonBlocking) = do
+      join $ atomically $ do
+        n <- readTVar doneVar
+        if n > 0
+          then do writeTVar doneVar (n - 1); pure $ go dstate k
+          else case mbNonBlocking of
+            Nothing -> retry
+            Just k' -> pure $ go dstate k'
+
+runAntiPipelinedPeerSenderQueue
+  :: forall ps pr dstate m.
+     ( MonadSTM    m
+     , MonadThread m
+     )
+  => TQueue m (SomeSender ps pr m)
+  -> TVar m Natural
+  -> Driver ps pr dstate m
+  -> m Void
+runAntiPipelinedPeerSenderQueue sendQueue doneVar
+                                Driver{sendMessage} = do
+
+    threadId <- myThreadId
+    labelThread threadId "antipipelined-sender-queue"
+    forever $ do
+      SomeSender sender <- atomically (readTQueue sendQueue)
+      runSender sender
+      atomically (modifyTVar' doneVar (+ 1))
+  where
+    runSender :: forall stA stZ. Sender ps pr stA stZ m -> m ()
+    runSender = \case
+      SenderEffect k         -> k >>= runSender
+      SenderDone             -> return ()
+      SenderYield refl msg k -> do
+        sendMessage refl msg
+        runSender k

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -154,7 +154,7 @@ runPeerWithDriver Driver{sendMessage, recvMessage, initialDState} =
       x' <- evaluate (force x)
       return (x', dstate)
 
-    go dstate (Yield2 refl msg k) = do
+    go dstate (Yield refl msg k) = do
       sendMessage refl msg
       go dstate k
 
@@ -293,16 +293,17 @@ runPipelinedPeerSender receiveQueue collectQueue
     go n    dstate             (Effect k) = k >>= go n dstate
     go Zero (HasDState dstate) (Done _ x) = return (x, dstate)
 
-    go n dstate (Yield2 refl msg k) = do
+    go Zero dstate (Yield refl msg k) = do
       sendMessage refl msg
-      go n dstate k
+      go Zero dstate k
 
     go Zero (HasDState dstate) (Await stok k) = do
       (SomeMessage msg, dstate') <- recvMessage stok dstate
       go Zero (HasDState dstate') (k msg)
 
-    go n dstate (AwaitPipelined receiver k) = do
+    go n dstate (YieldPipelined refl msg receiver k) = do
       atomically (writeTQueue receiveQueue (ReceiveHandler dstate receiver))
+      sendMessage refl msg
       go (Succ n) NoDState k
 
     go (Succ n) NoDState (Collect Nothing k) = do
@@ -384,7 +385,7 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- thread performs every 'recvMessage' (so it owns @dstate@ outright), and the
 -- sender thread performs every 'sendMessage'. The two only ever touch opposite
 -- directions of the channel, and the 'AntiOutstanding' index guarantees that
--- the peer thread's own sends ('Yield2'\/'Done') happen only when the sender
+-- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
 -- thread is idle.
 --
 runAntiPipelinedPeerWithDriver
@@ -443,7 +444,7 @@ runAntiPipelinedPeerMain sendVar doneVar
 
     -- Only reachable at 'AntiPipelined Z' (the constructor demands
     -- @AntiOutstanding ~ Z@), i.e. when the sender thread is provably idle.
-    go dstate (Yield2 refl msg k) = do
+    go dstate (Yield refl msg k) = do
       sendMessage refl msg
       go dstate k
 

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE CPP          #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 -- | Actions for running 'Peer's with a 'Driver'
 --
@@ -374,12 +375,6 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- Running anti-pipelined peers
 --
 
--- | An existential wrapper for a queued 'Sender', so that the sender thread's
--- queue can hold senders regardless of their (from\/to) state indices.
---
-data SomeSender ps pr m where
-     SomeSender :: Sender ps pr st stdone m -> SomeSender ps pr m
-
 -- | Run an anti-pipelined peer with the given driver.
 --
 -- Dual to 'runPipelinedPeerWithDriver': where a pipelined peer sends ahead and
@@ -402,12 +397,12 @@ runAntiPipelinedPeerWithDriver
   => Driver ps pr dstate m
   -> PeerAntiPipelined ps pr st m a
   -> m (a, dstate)
-runAntiPipelinedPeerWithDriver driver@Driver{initialDState} (PeerAntiPipelined peer) = do
-    sendQueue <- atomically newTQueue
-    doneVar   <- newTVarIO 0
-    r@(a, _dstate) <- runAntiPipelinedPeerSenderQueue sendQueue doneVar driver
+runAntiPipelinedPeerWithDriver driver@Driver{initialDState} (PeerAntiPipelined sender peer) = do
+    sendVar <- newTVarIO 0
+    doneVar <- newTVarIO 0
+    r@(a, _dstate) <- runAntiPipelinedPeerSender sender sendVar doneVar driver
            `withAsyncLoop`
-         runAntiPipelinedPeerMain       sendQueue doneVar driver peer initialDState
+         runAntiPipelinedPeerMain       sendVar doneVar driver peer initialDState
 
     _ <- evaluate (force a)
     return r
@@ -423,17 +418,17 @@ runAntiPipelinedPeerWithDriver driver@Driver{initialDState} (PeerAntiPipelined p
 
 
 runAntiPipelinedPeerMain
-  :: forall ps (st :: ps) pr dstate m a.
+  :: forall ps (apst :: ps) (apst' :: ps) (st :: ps) pr dstate m a.
      ( MonadSTM    m
      , MonadThread m
      )
-  => TQueue m (SomeSender ps pr m)
+  => TVar m Natural
   -> TVar m Natural
   -> Driver ps pr dstate m
-  -> Peer ps pr ('AntiPipelined Z) st m a
+  -> Peer ps pr ('AntiPipelined apst apst' Z) st m a
   -> dstate
   -> m (a, dstate)
-runAntiPipelinedPeerMain sendQueue doneVar
+runAntiPipelinedPeerMain sendVar doneVar
                          Driver{sendMessage, recvMessage}
                          peer0 dstate0 = do
     threadId <- myThreadId
@@ -442,7 +437,7 @@ runAntiPipelinedPeerMain sendQueue doneVar
   where
     go :: forall st' n.
           dstate
-       -> Peer ps pr ('AntiPipelined n) st' m a
+       -> Peer ps pr ('AntiPipelined apst apst' n) st' m a
        -> m (a, dstate)
     go dstate (Effect k) = k >>= go dstate
     go dstate (Done _ x) = return (x, dstate)
@@ -458,8 +453,8 @@ runAntiPipelinedPeerMain sendQueue doneVar
       (SomeMessage msg, dstate') <- recvMessage refl dstate
       go dstate' (k msg)
 
-    go dstate (YieldAntiPipelined _refl sender k) = do
-      atomically (writeTQueue sendQueue (SomeSender sender))
+    go dstate (YieldAntiPipelined _refl k) = do
+      atomically $ modifyTVar' sendVar (+ 1)
       go dstate k
 
     go dstate (AntiCollect k mbNonBlocking) = do
@@ -471,24 +466,25 @@ runAntiPipelinedPeerMain sendQueue doneVar
             Nothing -> retry
             Just k' -> pure $ go dstate k'
 
-runAntiPipelinedPeerSenderQueue
-  :: forall ps pr dstate m.
+runAntiPipelinedPeerSender
+  :: forall ps pr apst apst' dstate m.
      ( MonadSTM    m
      , MonadThread m
      )
-  => TQueue m (SomeSender ps pr m)
+  => Sender ps pr apst apst' m
+  -> TVar m Natural
   -> TVar m Natural
   -> Driver ps pr dstate m
   -> m Void
-runAntiPipelinedPeerSenderQueue sendQueue doneVar
+runAntiPipelinedPeerSender sender sendVar doneVar
                                 Driver{sendMessage} = do
 
     threadId <- myThreadId
-    labelThread threadId "antipipelined-sender-queue"
+    labelThread threadId "antipipelined-sender"
     forever $ do
-      SomeSender sender <- atomically (readTQueue sendQueue)
+      atomically $ do n <- readTVar sendVar; check (0 < n); writeTVar sendVar $! n - 1
       runSender sender
-      atomically (modifyTVar' doneVar (+ 1))
+      atomically $ modifyTVar' doneVar (+ 1)
   where
     runSender :: forall stA stZ. Sender ps pr stA stZ m -> m ()
     runSender = \case

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -154,7 +154,7 @@ runPeerWithDriver Driver{sendMessage, recvMessage, initialDState} =
       x' <- evaluate (force x)
       return (x', dstate)
 
-    go dstate (Yield refl msg k) = do
+    go dstate (Yield2 refl msg k) = do
       sendMessage refl msg
       go dstate k
 
@@ -293,17 +293,16 @@ runPipelinedPeerSender receiveQueue collectQueue
     go n    dstate             (Effect k) = k >>= go n dstate
     go Zero (HasDState dstate) (Done _ x) = return (x, dstate)
 
-    go Zero dstate (Yield refl msg k) = do
+    go n dstate (Yield2 refl msg k) = do
       sendMessage refl msg
-      go Zero dstate k
+      go n dstate k
 
     go Zero (HasDState dstate) (Await stok k) = do
       (SomeMessage msg, dstate') <- recvMessage stok dstate
       go Zero (HasDState dstate') (k msg)
 
-    go n dstate (YieldPipelined refl msg receiver k) = do
+    go n dstate (AwaitPipelined receiver k) = do
       atomically (writeTQueue receiveQueue (ReceiveHandler dstate receiver))
-      sendMessage refl msg
       go (Succ n) NoDState k
 
     go (Succ n) NoDState (Collect Nothing k) = do
@@ -385,7 +384,7 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- thread performs every 'recvMessage' (so it owns @dstate@ outright), and the
 -- sender thread performs every 'sendMessage'. The two only ever touch opposite
 -- directions of the channel, and the 'AntiOutstanding' index guarantees that
--- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
+-- the peer thread's own sends ('Yield2'\/'Done') happen only when the sender
 -- thread is idle.
 --
 runAntiPipelinedPeerWithDriver
@@ -444,7 +443,7 @@ runAntiPipelinedPeerMain sendVar doneVar
 
     -- Only reachable at 'AntiPipelined Z' (the constructor demands
     -- @AntiOutstanding ~ Z@), i.e. when the sender thread is provably idle.
-    go dstate (Yield refl msg k) = do
+    go dstate (Yield2 refl msg k) = do
       sendMessage refl msg
       go dstate k
 

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -14,8 +14,8 @@ module Network.TypedProtocol.Driver
   , runPeerWithDriver
     -- * Pipelined peers
   , runPipelinedPeerWithDriver
-    -- * Anti-pipelined peers
-  , runAntiPipelinedPeerWithDriver
+    -- * Dual-pipelined peers
+  , runDualPipelinedPeerWithDriver
   ) where
 
 import Control.Monad (forever, join)
@@ -384,25 +384,25 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- Unlike the pipelined driver, there is no trailing-data handoff: the peer
 -- thread performs every 'recvMessage' (so it owns @dstate@ outright), and the
 -- sender thread performs every 'sendMessage'. The two only ever touch opposite
--- directions of the channel, and the 'AntiOutstanding' index guarantees that
+-- directions of the channel, and the 'DualOutstanding' index guarantees that
 -- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
 -- thread is idle.
 --
-runAntiPipelinedPeerWithDriver
+runDualPipelinedPeerWithDriver
   :: forall ps (st :: ps) pr dstate m a.
      ( MonadAsync m
      , MonadEvaluate m
      , NFData a
      )
   => Driver ps pr dstate m
-  -> PeerAntiPipelined ps pr st m a
+  -> PeerDualPipelined ps pr st m a
   -> m (a, dstate)
-runAntiPipelinedPeerWithDriver driver@Driver{initialDState} (PeerAntiPipelined sender peer) = do
+runDualPipelinedPeerWithDriver driver@Driver{initialDState} (PeerDualPipelined sender peer) = do
     sendVar <- newTVarIO 0
     doneVar <- newTVarIO 0
-    r@(a, _dstate) <- runAntiPipelinedPeerSender sender sendVar doneVar driver
+    r@(a, _dstate) <- runDualPipelinedPeerSender sender sendVar doneVar driver
            `withAsyncLoop`
-         runAntiPipelinedPeerMain       sendVar doneVar driver peer initialDState
+         runDualPipelinedPeerMain       sendVar doneVar driver peer initialDState
 
     _ <- evaluate (force a)
     return r
@@ -417,7 +417,7 @@ runAntiPipelinedPeerWithDriver driver@Driver{initialDState} (PeerAntiPipelined s
         Right a -> return a
 
 
-runAntiPipelinedPeerMain
+runDualPipelinedPeerMain
   :: forall ps (apst :: ps) (apst' :: ps) (st :: ps) pr dstate m a.
      ( MonadSTM    m
      , MonadThread m
@@ -425,10 +425,10 @@ runAntiPipelinedPeerMain
   => TVar m Natural
   -> TVar m Natural
   -> Driver ps pr dstate m
-  -> Peer ps pr ('AntiPipelined apst apst' Z) st m a
+  -> Peer ps pr ('DualPipelined apst apst' Z) st m a
   -> dstate
   -> m (a, dstate)
-runAntiPipelinedPeerMain sendVar doneVar
+runDualPipelinedPeerMain sendVar doneVar
                          Driver{sendMessage, recvMessage}
                          peer0 dstate0 = do
     threadId <- myThreadId
@@ -437,27 +437,27 @@ runAntiPipelinedPeerMain sendVar doneVar
   where
     go :: forall st' n.
           dstate
-       -> Peer ps pr ('AntiPipelined apst apst' n) st' m a
+       -> Peer ps pr ('DualPipelined apst apst' n) st' m a
        -> m (a, dstate)
     go dstate (Effect k) = k >>= go dstate
     go dstate (Done _ x) = return (x, dstate)
 
-    -- Only reachable at 'AntiPipelined Z' (the constructor demands
-    -- @AntiOutstanding ~ Z@), i.e. when the sender thread is provably idle.
+    -- Only reachable at 'DualPipelined Z' (the constructor demands
+    -- @DualOutstanding ~ Z@), i.e. when the sender thread is provably idle.
     go dstate (Yield refl msg k) = do
       sendMessage refl msg
       go dstate k
 
-    -- Legal at any 'AntiOutstanding': receiving ahead is the whole point.
+    -- Legal at any 'DualOutstanding': receiving ahead is the whole point.
     go dstate (Await refl k) = do
       (SomeMessage msg, dstate') <- recvMessage refl dstate
       go dstate' (k msg)
 
-    go dstate (YieldAntiPipelined k) = do
+    go dstate (YieldDualPipelined k) = do
       atomically $ modifyTVar' sendVar (+ 1)
       go dstate k
 
-    go dstate (AntiCollect k mbNonBlocking) = do
+    go dstate (DualCollect k mbNonBlocking) = do
       join $ atomically $ do
         n <- readTVar doneVar
         if n > 0
@@ -466,7 +466,7 @@ runAntiPipelinedPeerMain sendVar doneVar
             Nothing -> retry
             Just k' -> pure $ go dstate k'
 
-runAntiPipelinedPeerSender
+runDualPipelinedPeerSender
   :: forall ps pr apst apst' dstate m.
      ( MonadSTM    m
      , MonadThread m
@@ -476,7 +476,7 @@ runAntiPipelinedPeerSender
   -> TVar m Natural
   -> Driver ps pr dstate m
   -> m Void
-runAntiPipelinedPeerSender sender sendVar doneVar
+runDualPipelinedPeerSender sender sendVar doneVar
                                 Driver{sendMessage} = do
 
     threadId <- myThreadId

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -154,7 +154,7 @@ runPeerWithDriver Driver{sendMessage, recvMessage, initialDState} =
       x' <- evaluate (force x)
       return (x', dstate)
 
-    go dstate (Yield2 refl msg k) = do
+    go dstate (Yield refl msg k) = do
       sendMessage refl msg
       go dstate k
 
@@ -293,7 +293,7 @@ runPipelinedPeerSender receiveQueue collectQueue
     go n    dstate             (Effect k) = k >>= go n dstate
     go Zero (HasDState dstate) (Done _ x) = return (x, dstate)
 
-    go n dstate (Yield2 refl msg k) = do
+    go n dstate (Yield refl msg k) = do
       sendMessage refl msg
       go n dstate k
 
@@ -384,7 +384,7 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- thread performs every 'recvMessage' (so it owns @dstate@ outright), and the
 -- sender thread performs every 'sendMessage'. The two only ever touch opposite
 -- directions of the channel, and the 'AntiOutstanding' index guarantees that
--- the peer thread's own sends ('Yield2'\/'Done') happen only when the sender
+-- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
 -- thread is idle.
 --
 runAntiPipelinedPeerWithDriver
@@ -443,7 +443,7 @@ runAntiPipelinedPeerMain sendVar doneVar
 
     -- Only reachable at 'AntiPipelined Z' (the constructor demands
     -- @AntiOutstanding ~ Z@), i.e. when the sender thread is provably idle.
-    go dstate (Yield2 refl msg k) = do
+    go dstate (Yield refl msg k) = do
       sendMessage refl msg
       go dstate k
 

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -154,7 +154,7 @@ runPeerWithDriver Driver{sendMessage, recvMessage, initialDState} =
       x' <- evaluate (force x)
       return (x', dstate)
 
-    go dstate (Yield refl msg k) = do
+    go dstate (Yield2 refl msg k) = do
       sendMessage refl msg
       go dstate k
 
@@ -293,7 +293,7 @@ runPipelinedPeerSender receiveQueue collectQueue
     go n    dstate             (Effect k) = k >>= go n dstate
     go Zero (HasDState dstate) (Done _ x) = return (x, dstate)
 
-    go n dstate (Yield refl msg k) = do
+    go n dstate (Yield2 refl msg k) = do
       sendMessage refl msg
       go n dstate k
 
@@ -384,7 +384,7 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- thread performs every 'recvMessage' (so it owns @dstate@ outright), and the
 -- sender thread performs every 'sendMessage'. The two only ever touch opposite
 -- directions of the channel, and the 'AntiOutstanding' index guarantees that
--- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
+-- the peer thread's own sends ('Yield2'\/'Done') happen only when the sender
 -- thread is idle.
 --
 runAntiPipelinedPeerWithDriver
@@ -443,7 +443,7 @@ runAntiPipelinedPeerMain sendVar doneVar
 
     -- Only reachable at 'AntiPipelined Z' (the constructor demands
     -- @AntiOutstanding ~ Z@), i.e. when the sender thread is provably idle.
-    go dstate (Yield refl msg k) = do
+    go dstate (Yield2 refl msg k) = do
       sendMessage refl msg
       go dstate k
 

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -15,7 +15,7 @@ module Network.TypedProtocol.Driver
     -- * Pipelined peers
   , runPipelinedPeerWithDriver
     -- * Dual-pipelined peers
-  , runDualPipelinedPeerWithDriver
+  , runDualPipelined1PeerWithDriver
   ) where
 
 import Control.Monad (forever, join)
@@ -388,21 +388,21 @@ runPipelinedPeerReceiver Driver{recvMessage} = go
 -- the peer thread's own sends ('Yield'\/'Done') happen only when the sender
 -- thread is idle.
 --
-runDualPipelinedPeerWithDriver
+runDualPipelined1PeerWithDriver
   :: forall ps (st :: ps) pr dstate m a.
      ( MonadAsync m
      , MonadEvaluate m
      , NFData a
      )
   => Driver ps pr dstate m
-  -> PeerDualPipelined ps pr st m a
+  -> PeerDualPipelined1 ps pr st m a
   -> m (a, dstate)
-runDualPipelinedPeerWithDriver driver@Driver{initialDState} (PeerDualPipelined sender peer) = do
+runDualPipelined1PeerWithDriver driver@Driver{initialDState} (PeerDualPipelined1 sender peer) = do
     sendVar <- newTVarIO 0
     doneVar <- newTVarIO 0
-    r@(a, _dstate) <- runDualPipelinedPeerSender sender sendVar doneVar driver
+    r@(a, _dstate) <- runDualPipelined1PeerSender sender sendVar doneVar driver
            `withAsyncLoop`
-         runDualPipelinedPeerMain       sendVar doneVar driver peer initialDState
+         runDualPipelined1PeerMain       sendVar doneVar driver peer initialDState
 
     _ <- evaluate (force a)
     return r
@@ -417,7 +417,7 @@ runDualPipelinedPeerWithDriver driver@Driver{initialDState} (PeerDualPipelined s
         Right a -> return a
 
 
-runDualPipelinedPeerMain
+runDualPipelined1PeerMain
   :: forall ps (apst :: ps) (apst' :: ps) (st :: ps) pr dstate m a.
      ( MonadSTM    m
      , MonadThread m
@@ -425,10 +425,10 @@ runDualPipelinedPeerMain
   => TVar m Natural
   -> TVar m Natural
   -> Driver ps pr dstate m
-  -> Peer ps pr ('DualPipelined apst apst' Z) st m a
+  -> Peer ps pr ('DualPipelined1 apst apst' Z) st m a
   -> dstate
   -> m (a, dstate)
-runDualPipelinedPeerMain sendVar doneVar
+runDualPipelined1PeerMain sendVar doneVar
                          Driver{sendMessage, recvMessage}
                          peer0 dstate0 = do
     threadId <- myThreadId
@@ -437,12 +437,12 @@ runDualPipelinedPeerMain sendVar doneVar
   where
     go :: forall st' n.
           dstate
-       -> Peer ps pr ('DualPipelined apst apst' n) st' m a
+       -> Peer ps pr ('DualPipelined1 apst apst' n) st' m a
        -> m (a, dstate)
     go dstate (Effect k) = k >>= go dstate
     go dstate (Done _ x) = return (x, dstate)
 
-    -- Only reachable at 'DualPipelined Z' (the constructor demands
+    -- Only reachable at 'DualPipelined1 Z' (the constructor demands
     -- @DualOutstanding ~ Z@), i.e. when the sender thread is provably idle.
     go dstate (Yield refl msg k) = do
       sendMessage refl msg
@@ -453,11 +453,11 @@ runDualPipelinedPeerMain sendVar doneVar
       (SomeMessage msg, dstate') <- recvMessage refl dstate
       go dstate' (k msg)
 
-    go dstate (YieldDualPipelined k) = do
+    go dstate (YieldDualPipelined1 k) = do
       atomically $ modifyTVar' sendVar (+ 1)
       go dstate k
 
-    go dstate (DualCollect k mbNonBlocking) = do
+    go dstate (DualCollect1 k mbNonBlocking) = do
       join $ atomically $ do
         n <- readTVar doneVar
         if n > 0
@@ -466,7 +466,7 @@ runDualPipelinedPeerMain sendVar doneVar
             Nothing -> retry
             Just k' -> pure $ go dstate k'
 
-runDualPipelinedPeerSender
+runDualPipelined1PeerSender
   :: forall ps pr apst apst' dstate m.
      ( MonadSTM    m
      , MonadThread m
@@ -476,7 +476,7 @@ runDualPipelinedPeerSender
   -> TVar m Natural
   -> Driver ps pr dstate m
   -> m Void
-runDualPipelinedPeerSender sender sendVar doneVar
+runDualPipelined1PeerSender sender sendVar doneVar
                                 Driver{sendMessage} = do
 
     threadId <- myThreadId

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -5,7 +5,7 @@
 module Network.TypedProtocol.Peer
   ( Peer (..)
   , PeerPipelined (..)
-  , PeerAntiPipelined (..)
+  , PeerDualPipelined (..)
   , Receiver (..)
   , Sender (..)
   , Outstanding
@@ -117,7 +117,7 @@ data Peer ps pr pl st m a where
        , StateTokenI st'
        , ActiveState st
        , Outstanding pl ~ Z
-       , AntiOutstanding pl ~ Z
+       , DualOutstanding pl ~ Z
        )
     => WeHaveAgencyProof pr st
     -- ^ agency proof
@@ -172,7 +172,7 @@ data Peer ps pr pl st m a where
        ( StateTokenI st
        , StateAgency st ~ NobodyAgency
        , Outstanding pl ~ Z
-       , AntiOutstanding pl ~ Z
+       , DualOutstanding pl ~ Z
        )
     => NobodyHasAgencyProof pr st
     -- ^ (no) agency proof
@@ -218,31 +218,31 @@ data Peer ps pr pl st m a where
     -- ^ continuation
     -> Peer        ps pr (Pipelined (S n) c) st m a
 
-  -- | 'AntiPipelined' analog of 'YieldPipelined'
+  -- | 'DualPipelined' analog of 'YieldPipelined'
   --
   -- Always uses the 'Sender' that was provided to the driver alongside this
   -- 'Peer'. No agency proof is needed here: each message the 'Sender' actually
   -- sends is guarded by that 'Sender'\'s own 'SenderYield' proof, and a 'Sender'
   -- that sends nothing needs no agency.
-  YieldAntiPipelined
+  YieldDualPipelined
     :: forall ps pr (st :: ps) n (st' :: ps) m a.
        ( StateTokenI st
        , StateTokenI st'
        )
-    => Peer ps pr (AntiPipelined st st' (S n)) st' m a
+    => Peer ps pr (DualPipelined st st' (S n)) st' m a
        -- ^ continuation, before or after sending
-    -> Peer ps pr (AntiPipelined st st'  n ) st  m a
+    -> Peer ps pr (DualPipelined st st'  n ) st  m a
 
-  AntiCollect
+  DualCollect
     :: forall ps pr n st apst apst' m a.
        StateTokenI st
-    =>        Peer ps pr (AntiPipelined apst apst'   n ) st m a
+    =>        Peer ps pr (DualPipelined apst apst'   n ) st m a
        -- ^ how to proceed if/once the @n+1@st 'Sender' has already terminated
-    -> Maybe (Peer ps pr (AntiPipelined apst apst' (S n)) st m a)
+    -> Maybe (Peer ps pr (DualPipelined apst apst' (S n)) st m a)
        -- ^ 'Just' if and only if the peer can proceed before the @n+1@st 'Sender' has terminated
        --
        -- This is ignored if a message has already been sent
-    -> Peer ps pr (AntiPipelined apst apst' (S n)) st m a
+    -> Peer ps pr (DualPipelined apst apst' (S n)) st m a
 
 deriving instance Functor m => Functor (Peer ps pr pl st m)
 
@@ -289,7 +289,7 @@ data Receiver ps pr st stdone m c where
 
 deriving instance Functor m => Functor (Receiver ps pr st stdone m)
 
--- | 'AntiPipelined' analog of 'Receiver'
+-- | 'DualPipelined' analog of 'Receiver'
 type Sender :: forall ps
             -> PeerRole
             -> ps
@@ -324,10 +324,10 @@ data PeerPipelined ps pr (st :: ps) m a where
 
 deriving instance Functor m => Functor (PeerPipelined ps pr st m)
 
-data PeerAntiPipelined ps pr (st :: ps) m a where
-    PeerAntiPipelined ::
+data PeerDualPipelined ps pr (st :: ps) m a where
+    PeerDualPipelined ::
       Sender ps pr apst apst' m ->
-      Peer ps pr (AntiPipelined apst apst' Z) st m a ->
-      PeerAntiPipelined ps pr st m a
+      Peer ps pr (DualPipelined apst apst' Z) st m a ->
+      PeerDualPipelined ps pr st m a
 
-deriving instance Functor m => Functor (PeerAntiPipelined ps pr st m)
+deriving instance Functor m => Functor (PeerDualPipelined ps pr st m)

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -116,7 +116,6 @@ data Peer ps pr pl st m a where
        ( StateTokenI st
        , StateTokenI st'
        , ActiveState st
-       , Outstanding pl ~ Z
        , AntiOutstanding pl ~ Z
        )
     => WeHaveAgencyProof pr st
@@ -184,24 +183,17 @@ data Peer ps pr pl st m a where
   -- Pipelining primitives
   --
 
-  -- | Pipelined send.  We statically decide from which state we continue (the
-  -- `st''` state here), the gap (between `st'` and `st''`) must be fulfilled
-  -- by 'Receiver' which runs will run in parallel.
+  -- | Reserve a pipelined receive: fork a 'Receiver' (run in parallel by the
+  -- driver) that consumes the transitions from the current state @st@ up to
+  -- @st'@, and continue from @st'@ with one more outstanding receiver.
   --
-  YieldPipelined
-    :: forall ps pr (st :: ps) (st' :: ps) c n st'' m a.
-       ( StateTokenI st
-       , StateTokenI st'
-       , ActiveState st
-       )
-    => WeHaveAgencyProof pr st
-    -- ^ agency proof
-    -> Message ps st st'
-    -- ^ protocol message
-    -> Receiver ps pr st' st'' m c
-    -- ^ receiver
-    -> Peer ps pr (Pipelined (S n) c) st'' m a
-    -- ^ continuation from state `st''`
+  AwaitPipelined
+    :: forall ps pr (st :: ps) c n (st' :: ps) m a.
+       StateTokenI st
+    => Receiver ps pr st st' m c
+    -- ^ receiver, starting from the current state
+    -> Peer ps pr (Pipelined (S n) c) st' m a
+    -- ^ continuation from state `st'`
     -> Peer ps pr (Pipelined    n  c)   st   m a
 
   -- | Collect results returned by a `Receiver`.  Results are collected in the

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -237,7 +237,7 @@ data Peer ps pr pl st m a where
     :: forall ps pr n st apst apst' m a.
        StateTokenI st
     =>        Peer ps pr (AntiPipelined apst apst'   n ) st m a
-       -- ^ how to proceed if the @n+1@fst 'Sender' has already terminated
+       -- ^ how to proceed if/once the @n+1@st 'Sender' has already terminated
     -> Maybe (Peer ps pr (AntiPipelined apst apst' (S n)) st m a)
        -- ^ 'Just' if and only if the peer can proceed before the @n+1@st 'Sender' has terminated
        --

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -228,7 +228,6 @@ data Peer ps pr pl st m a where
     :: forall ps pr (st :: ps) n (st' :: ps) m a.
        ( StateTokenI st
        , StateTokenI st'
-       , ActiveState st
        )
     => Peer ps pr (AntiPipelined st st' (S n)) st' m a
        -- ^ continuation, before or after sending

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -220,16 +220,17 @@ data Peer ps pr pl st m a where
 
   -- | 'AntiPipelined' analog of 'YieldPipelined'
   --
-  -- Always uses the 'Sender' that was provided to the driver
-  -- alongside this 'Peer'.
+  -- Always uses the 'Sender' that was provided to the driver alongside this
+  -- 'Peer'. No agency proof is needed here: each message the 'Sender' actually
+  -- sends is guarded by that 'Sender'\'s own 'SenderYield' proof, and a 'Sender'
+  -- that sends nothing needs no agency.
   YieldAntiPipelined
     :: forall ps pr (st :: ps) n (st' :: ps) m a.
        ( StateTokenI st
        , StateTokenI st'
        , ActiveState st
        )
-    => !(WeHaveAgencyProof pr st)
-    -> Peer ps pr (AntiPipelined st st' (S n)) st' m a
+    => Peer ps pr (AntiPipelined st st' (S n)) st' m a
        -- ^ continuation, before or after sending
     -> Peer ps pr (AntiPipelined st st'  n ) st  m a
 

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -81,7 +81,7 @@ import Network.TypedProtocol.Core as Core
 --
 type Peer :: forall ps
           -> PeerRole
-          -> IsPipelined
+          -> IsPipelined ps
           -> ps
           -> (Type -> Type)
           -- ^ monad's kind
@@ -219,6 +219,9 @@ data Peer ps pr pl st m a where
     -> Peer        ps pr (Pipelined (S n) c) st m a
 
   -- | 'AntiPipelined' analog of 'YieldPipelined'
+  --
+  -- Always uses the 'Sender' that was provided to the driver
+  -- alongside this 'Peer'.
   YieldAntiPipelined
     :: forall ps pr (st :: ps) n (st' :: ps) m a.
        ( StateTokenI st
@@ -226,22 +229,20 @@ data Peer ps pr pl st m a where
        , ActiveState st
        )
     => !(WeHaveAgencyProof pr st)
-    -> Sender ps pr st st' m
-       -- ^ how to send
-    -> Peer ps pr (AntiPipelined (S n)) st' m a
+    -> Peer ps pr (AntiPipelined st st' (S n)) st' m a
        -- ^ continuation, before or after sending
-    -> Peer ps pr (AntiPipelined    n ) st  m a
+    -> Peer ps pr (AntiPipelined st st'  n ) st  m a
 
   AntiCollect
-    :: forall ps pr n st m a.
+    :: forall ps pr n st apst apst' m a.
        StateTokenI st
-    =>        Peer ps pr (AntiPipelined    n ) st m a
+    =>        Peer ps pr (AntiPipelined apst apst'   n ) st m a
        -- ^ how to proceed if the @n+1@fst 'Sender' has already terminated
-    -> Maybe (Peer ps pr (AntiPipelined (S n)) st m a)
+    -> Maybe (Peer ps pr (AntiPipelined apst apst' (S n)) st m a)
        -- ^ 'Just' if and only if the peer can proceed before the @n+1@st 'Sender' has terminated
        --
        -- This is ignored if a message has already been sent
-    -> Peer ps pr (AntiPipelined (S n)) st m a
+    -> Peer ps pr (AntiPipelined apst apst' (S n)) st m a
 
 deriving instance Functor m => Functor (Peer ps pr pl st m)
 
@@ -324,7 +325,9 @@ data PeerPipelined ps pr (st :: ps) m a where
 deriving instance Functor m => Functor (PeerPipelined ps pr st m)
 
 data PeerAntiPipelined ps pr (st :: ps) m a where
-    PeerAntiPipelined :: { runPeerAntiPipelined :: Peer ps pr (AntiPipelined Z) st m a }
-                  -> PeerAntiPipelined ps pr st m a
+    PeerAntiPipelined ::
+      Sender ps pr apst apst' m ->
+      Peer ps pr (AntiPipelined apst apst' Z) st m a ->
+      PeerAntiPipelined ps pr st m a
 
 deriving instance Functor m => Functor (PeerAntiPipelined ps pr st m)

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -218,21 +218,29 @@ data Peer ps pr pl st m a where
     -- ^ continuation
     -> Peer        ps pr (Pipelined (S n) c) st m a
 
-  -- | 'DualPipelined1' analog of 'YieldPipelined'
+  -- | "Fork"/"spawn" a 'Sender' that will transition from @st@ to @st'@ by
+  -- sending zero or more messages without /receiving/ any, and then proceed as
+  -- if already in @st'@ even without necessarily waiting for the 'Sender' to
+  -- finish
   --
-  -- Always uses the 'Sender' that was provided to the driver alongside this
-  -- 'Peer'. No agency proof is needed here: each message the 'Sender' actually
-  -- sends is guarded by that 'Sender'\'s own 'SenderYield' proof, and a 'Sender'
-  -- that sends nothing needs no agency.
+  -- So that the 'Peer''s driver can maintain merely a counter instead of a
+  -- queue, this always uses the same 'Sender', which was provided to the driver
+  -- alongside this 'Peer'. Hence the @1@ suffix.
+  --
+  -- Note that 'YieldPipelined' both sends a message and provides a receiver;
+  -- that is unnecessary, it could be decomposed into a plain 'Yield' and the
+  -- core 'Pipelined' primitive, which would only have a 'Receiver'
+  -- argument. That primitive would be explicitly symmetric to the hypothetical
+  -- @YieldDualPipelined@ that takes a 'Sender' to be enqueued (instead of the
+  -- @...1@ optimization present here).
   YieldDualPipelined1
     :: forall ps pr (st :: ps) n (st' :: ps) m a.
        ( StateTokenI st
        , StateTokenI st'
        )
-    => {- Sender ps pr st st' m
-    -> -} Peer ps pr (DualPipelined1 st st' (S n)) st' m a
-       -- ^ continuation, before or after sending
-    -> Peer ps pr (DualPipelined1 st st'  n ) st  m a
+    => Peer ps pr (DualPipelined1 st st' (S n)) st' m a
+       -- ^ continuation, before or after the 'Sender' finishes
+    -> Peer ps pr (DualPipelined1 st st'    n ) st  m a
 
   DualCollect1
     :: forall ps pr n st apst apst' m a.

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -116,6 +116,7 @@ data Peer ps pr pl st m a where
        ( StateTokenI st
        , StateTokenI st'
        , ActiveState st
+       , Outstanding pl ~ Z
        , AntiOutstanding pl ~ Z
        )
     => WeHaveAgencyProof pr st
@@ -183,17 +184,24 @@ data Peer ps pr pl st m a where
   -- Pipelining primitives
   --
 
-  -- | Reserve a pipelined receive: fork a 'Receiver' (run in parallel by the
-  -- driver) that consumes the transitions from the current state @st@ up to
-  -- @st'@, and continue from @st'@ with one more outstanding receiver.
+  -- | Pipelined send.  We statically decide from which state we continue (the
+  -- `st''` state here), the gap (between `st'` and `st''`) must be fulfilled
+  -- by 'Receiver' which runs will run in parallel.
   --
-  AwaitPipelined
-    :: forall ps pr (st :: ps) c n (st' :: ps) m a.
-       StateTokenI st
-    => Receiver ps pr st st' m c
-    -- ^ receiver, starting from the current state
-    -> Peer ps pr (Pipelined (S n) c) st' m a
-    -- ^ continuation from state `st'`
+  YieldPipelined
+    :: forall ps pr (st :: ps) (st' :: ps) c n st'' m a.
+       ( StateTokenI st
+       , StateTokenI st'
+       , ActiveState st
+       )
+    => WeHaveAgencyProof pr st
+    -- ^ agency proof
+    -> Message ps st st'
+    -- ^ protocol message
+    -> Receiver ps pr st' st'' m c
+    -- ^ receiver
+    -> Peer ps pr (Pipelined (S n) c) st'' m a
+    -- ^ continuation from state `st''`
     -> Peer ps pr (Pipelined    n  c)   st   m a
 
   -- | Collect results returned by a `Receiver`.  Results are collected in the

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -5,7 +5,7 @@
 module Network.TypedProtocol.Peer
   ( Peer (..)
   , PeerPipelined (..)
-  , PeerDualPipelined (..)
+  , PeerDualPipelined1 (..)
   , Receiver (..)
   , Sender (..)
   , Outstanding
@@ -218,31 +218,32 @@ data Peer ps pr pl st m a where
     -- ^ continuation
     -> Peer        ps pr (Pipelined (S n) c) st m a
 
-  -- | 'DualPipelined' analog of 'YieldPipelined'
+  -- | 'DualPipelined1' analog of 'YieldPipelined'
   --
   -- Always uses the 'Sender' that was provided to the driver alongside this
   -- 'Peer'. No agency proof is needed here: each message the 'Sender' actually
   -- sends is guarded by that 'Sender'\'s own 'SenderYield' proof, and a 'Sender'
   -- that sends nothing needs no agency.
-  YieldDualPipelined
+  YieldDualPipelined1
     :: forall ps pr (st :: ps) n (st' :: ps) m a.
        ( StateTokenI st
        , StateTokenI st'
        )
-    => Peer ps pr (DualPipelined st st' (S n)) st' m a
+    => {- Sender ps pr st st' m
+    -> -} Peer ps pr (DualPipelined1 st st' (S n)) st' m a
        -- ^ continuation, before or after sending
-    -> Peer ps pr (DualPipelined st st'  n ) st  m a
+    -> Peer ps pr (DualPipelined1 st st'  n ) st  m a
 
-  DualCollect
+  DualCollect1
     :: forall ps pr n st apst apst' m a.
        StateTokenI st
-    =>        Peer ps pr (DualPipelined apst apst'   n ) st m a
+    =>        Peer ps pr (DualPipelined1 apst apst'   n ) st m a
        -- ^ how to proceed if/once the @n+1@st 'Sender' has already terminated
-    -> Maybe (Peer ps pr (DualPipelined apst apst' (S n)) st m a)
+    -> Maybe (Peer ps pr (DualPipelined1 apst apst' (S n)) st m a)
        -- ^ 'Just' if and only if the peer can proceed before the @n+1@st 'Sender' has terminated
        --
        -- This is ignored if a message has already been sent
-    -> Peer ps pr (DualPipelined apst apst' (S n)) st m a
+    -> Peer ps pr (DualPipelined1 apst apst' (S n)) st m a
 
 deriving instance Functor m => Functor (Peer ps pr pl st m)
 
@@ -289,7 +290,7 @@ data Receiver ps pr st stdone m c where
 
 deriving instance Functor m => Functor (Receiver ps pr st stdone m)
 
--- | 'DualPipelined' analog of 'Receiver'
+-- | 'DualPipelined1' analog of 'Receiver'
 type Sender :: forall ps
             -> PeerRole
             -> ps
@@ -324,10 +325,10 @@ data PeerPipelined ps pr (st :: ps) m a where
 
 deriving instance Functor m => Functor (PeerPipelined ps pr st m)
 
-data PeerDualPipelined ps pr (st :: ps) m a where
-    PeerDualPipelined ::
+data PeerDualPipelined1 ps pr (st :: ps) m a where
+    PeerDualPipelined1 ::
       Sender ps pr apst apst' m ->
-      Peer ps pr (DualPipelined apst apst' Z) st m a ->
-      PeerDualPipelined ps pr st m a
+      Peer ps pr (DualPipelined1 apst apst' Z) st m a ->
+      PeerDualPipelined1 ps pr st m a
 
-deriving instance Functor m => Functor (PeerDualPipelined ps pr st m)
+deriving instance Functor m => Functor (PeerDualPipelined1 ps pr st m)

--- a/typed-protocols/src/Network/TypedProtocol/Peer.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer.hs
@@ -5,7 +5,9 @@
 module Network.TypedProtocol.Peer
   ( Peer (..)
   , PeerPipelined (..)
+  , PeerAntiPipelined (..)
   , Receiver (..)
+  , Sender (..)
   , Outstanding
   , N (..)
   , Nat (Zero, Succ)
@@ -115,6 +117,7 @@ data Peer ps pr pl st m a where
        , StateTokenI st'
        , ActiveState st
        , Outstanding pl ~ Z
+       , AntiOutstanding pl ~ Z
        )
     => WeHaveAgencyProof pr st
     -- ^ agency proof
@@ -169,6 +172,7 @@ data Peer ps pr pl st m a where
        ( StateTokenI st
        , StateAgency st ~ NobodyAgency
        , Outstanding pl ~ Z
+       , AntiOutstanding pl ~ Z
        )
     => NobodyHasAgencyProof pr st
     -- ^ (no) agency proof
@@ -214,8 +218,32 @@ data Peer ps pr pl st m a where
     -- ^ continuation
     -> Peer        ps pr (Pipelined (S n) c) st m a
 
-deriving instance Functor m => Functor (Peer ps pr pl st m)
+  -- | 'AntiPipelined' analog of 'YieldPipelined'
+  YieldAntiPipelined
+    :: forall ps pr (st :: ps) n (st' :: ps) m a.
+       ( StateTokenI st
+       , StateTokenI st'
+       , ActiveState st
+       )
+    => !(WeHaveAgencyProof pr st)
+    -> Sender ps pr st st' m
+       -- ^ how to send
+    -> Peer ps pr (AntiPipelined (S n)) st' m a
+       -- ^ continuation, before or after sending
+    -> Peer ps pr (AntiPipelined    n ) st  m a
 
+  AntiCollect
+    :: forall ps pr n st m a.
+       StateTokenI st
+    =>        Peer ps pr (AntiPipelined    n ) st m a
+       -- ^ how to proceed if the @n+1@fst 'Sender' has already terminated
+    -> Maybe (Peer ps pr (AntiPipelined (S n)) st m a)
+       -- ^ 'Just' if and only if the peer can proceed before the @n+1@st 'Sender' has terminated
+       --
+       -- This is ignored if a message has already been sent
+    -> Peer ps pr (AntiPipelined (S n)) st m a
+
+deriving instance Functor m => Functor (Peer ps pr pl st m)
 
 -- | Receiver.  It is limited to only awaiting for messages and running monadic
 -- computations.  This means that one can only pipeline messages if they can be
@@ -260,6 +288,29 @@ data Receiver ps pr st stdone m c where
 
 deriving instance Functor m => Functor (Receiver ps pr st stdone m)
 
+-- | 'AntiPipelined' analog of 'Receiver'
+type Sender :: forall ps
+            -> PeerRole
+            -> ps
+            -> ps
+            -> (Type -> Type)
+            -> Type
+data Sender ps pr st stdone m where
+
+  SenderEffect :: m (Sender ps pr st stdone m)
+               ->    Sender ps pr st stdone m
+
+  SenderDone   :: Sender ps pr stdone stdone m
+
+  SenderYield  :: ( StateTokenI st
+                  , StateTokenI st'
+                  , ActiveState st
+                  )
+               => !(WeHaveAgencyProof pr st)
+               -> Message ps st st'
+               -> Sender ps pr st' stdone m
+               -> Sender ps pr st  stdone m
+
 -- | A description of a peer that engages in a protocol in a pipelined fashion.
 --
 -- This type is useful for wrapping pipelined peers to hide information which
@@ -271,3 +322,9 @@ data PeerPipelined ps pr (st :: ps) m a where
                   -> PeerPipelined ps pr st m a
 
 deriving instance Functor m => Functor (PeerPipelined ps pr st m)
+
+data PeerAntiPipelined ps pr (st :: ps) m a where
+    PeerAntiPipelined :: { runPeerAntiPipelined :: Peer ps pr (AntiPipelined Z) st m a }
+                  -> PeerAntiPipelined ps pr st m a
+
+deriving instance Functor m => Functor (PeerAntiPipelined ps pr st m)

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -75,6 +75,7 @@ pattern Yield :: forall ps pl st m a.
                  ( StateTokenI st
                  , StateTokenI st'
                  , StateAgency st ~ ClientAgency
+                 , Outstanding pl ~ Z
                  , AntiOutstanding pl ~ Z
                  )
               => Message ps st st'
@@ -82,7 +83,7 @@ pattern Yield :: forall ps pl st m a.
               -> Client ps pl st' m a
               -- ^ continuation
               -> Client ps pl st  m a
-pattern Yield msg k = TP.Yield2 ReflClientAgency msg k
+pattern Yield msg k = TP.Yield ReflClientAgency msg k
 
 
 -- | Client role pattern for 'TP.Await'
@@ -130,7 +131,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Client ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Client ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.Yield2 ReflClientAgency msg (TP.AwaitPipelined receiver k)
+pattern YieldPipelined msg receiver k = TP.YieldPipelined ReflClientAgency msg receiver k
 
 
 -- | Client role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -75,7 +75,6 @@ pattern Yield :: forall ps pl st m a.
                  ( StateTokenI st
                  , StateTokenI st'
                  , StateAgency st ~ ClientAgency
-                 , Outstanding pl ~ Z
                  , AntiOutstanding pl ~ Z
                  )
               => Message ps st st'
@@ -83,7 +82,7 @@ pattern Yield :: forall ps pl st m a.
               -> Client ps pl st' m a
               -- ^ continuation
               -> Client ps pl st  m a
-pattern Yield msg k = TP.Yield ReflClientAgency msg k
+pattern Yield msg k = TP.Yield2 ReflClientAgency msg k
 
 
 -- | Client role pattern for 'TP.Await'
@@ -131,7 +130,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Client ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Client ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.YieldPipelined ReflClientAgency msg receiver k
+pattern YieldPipelined msg receiver k = TP.Yield2 ReflClientAgency msg (TP.AwaitPipelined receiver k)
 
 
 -- | Client role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -76,6 +76,7 @@ pattern Yield :: forall ps pl st m a.
                  , StateTokenI st'
                  , StateAgency st ~ ClientAgency
                  , Outstanding pl ~ Z
+                 , AntiOutstanding pl ~ Z
                  )
               => Message ps st st'
               -- ^ protocol message
@@ -107,6 +108,7 @@ pattern Done :: forall ps pl st m a.
              => ( StateTokenI st
                 , StateAgency st ~ NobodyAgency
                 , Outstanding pl ~ Z
+                , AntiOutstanding pl ~ Z
                 )
              => a
              -- ^ protocol return value

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -76,7 +76,7 @@ pattern Yield :: forall ps pl st m a.
                  , StateTokenI st'
                  , StateAgency st ~ ClientAgency
                  , Outstanding pl ~ Z
-                 , AntiOutstanding pl ~ Z
+                 , DualOutstanding pl ~ Z
                  )
               => Message ps st st'
               -- ^ protocol message
@@ -108,7 +108,7 @@ pattern Done :: forall ps pl st m a.
              => ( StateTokenI st
                 , StateAgency st ~ NobodyAgency
                 , Outstanding pl ~ Z
-                , AntiOutstanding pl ~ Z
+                , DualOutstanding pl ~ Z
                 )
              => a
              -- ^ protocol return value

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -82,7 +82,7 @@ pattern Yield :: forall ps pl st m a.
               -> Client ps pl st' m a
               -- ^ continuation
               -> Client ps pl st  m a
-pattern Yield msg k = TP.Yield ReflClientAgency msg k
+pattern Yield msg k = TP.Yield2 ReflClientAgency msg k
 
 
 -- | Client role pattern for 'TP.Await'
@@ -130,7 +130,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Client ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Client ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.Yield ReflClientAgency msg (TP.AwaitPipelined receiver k)
+pattern YieldPipelined msg receiver k = TP.Yield2 ReflClientAgency msg (TP.AwaitPipelined receiver k)
 
 
 -- | Client role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -82,7 +82,7 @@ pattern Yield :: forall ps pl st m a.
               -> Client ps pl st' m a
               -- ^ continuation
               -> Client ps pl st  m a
-pattern Yield msg k = TP.Yield2 ReflClientAgency msg k
+pattern Yield msg k = TP.Yield ReflClientAgency msg k
 
 
 -- | Client role pattern for 'TP.Await'
@@ -130,7 +130,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Client ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Client ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.Yield2 ReflClientAgency msg (TP.AwaitPipelined receiver k)
+pattern YieldPipelined msg receiver k = TP.Yield ReflClientAgency msg (TP.AwaitPipelined receiver k)
 
 
 -- | Client role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Client.hs
@@ -36,7 +36,7 @@ import Network.TypedProtocol.Peer qualified as TP
 
 
 type Client :: forall ps
-            -> IsPipelined
+            -> IsPipelined ps
             -> ps
             -> (Type -> Type)
             -> Type

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -105,6 +105,7 @@ pattern Yield :: forall ps pl st m a.
                  ( StateTokenI st
                  , StateTokenI st'
                  , StateAgency st ~ ServerAgency
+                 , Outstanding pl ~ Z
                  , AntiOutstanding pl ~ Z
                  )
               => Message ps st st'
@@ -112,7 +113,7 @@ pattern Yield :: forall ps pl st m a.
               -> Server ps pl st' m a
               -- ^ continuation
               -> Server ps pl st  m a
-pattern Yield msg k = TP.Yield2 ReflServerAgency msg k
+pattern Yield msg k = TP.Yield ReflServerAgency msg k
 
 
 -- | Server role pattern for 'TP.Await'
@@ -160,7 +161,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Server ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Server ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.Yield2 ReflServerAgency msg (TP.AwaitPipelined receiver k)
+pattern YieldPipelined msg receiver k = TP.YieldPipelined ReflServerAgency msg receiver k
 
 
 -- | Server role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -14,8 +14,8 @@ module Network.TypedProtocol.Peer.Server
   , pattern Done
   , pattern YieldPipelined
   , pattern Collect
-  , pattern YieldAntiPipelined
-  , pattern AntiCollect
+  , pattern YieldDualPipelined
+  , pattern DualCollect
     -- * Receiver type alias and its pattern synonyms
   , Receiver
   , pattern ReceiverEffect
@@ -29,13 +29,13 @@ module Network.TypedProtocol.Peer.Server
     -- * ServerPipelined type alias and its pattern synonym
   , ServerPipelined
   , TP.PeerPipelined (ServerPipelined, runServerPipelined)
-    -- * ServerAntiPipelined type alias and its pattern synonym
-  , ServerAntiPipelined
-  , pattern ServerAntiPipelined
+    -- * ServerDualPipelined type alias and its pattern synonym
+  , ServerDualPipelined
+  , pattern ServerDualPipelined
     -- * re-exports
   , IsPipelined (..)
   , Outstanding
-  , AntiOutstanding
+  , DualOutstanding
   , N (..)
   , Nat (..)
   ) where
@@ -74,18 +74,18 @@ pattern ServerPipelined { runServerPipelined } = TP.PeerPipelined runServerPipel
 -- | A description of a peer that engages in a protocol in an anti-pipelined
 -- fashion (ie non-blocking sends).
 --
-type ServerAntiPipelined ps st m a = TP.PeerAntiPipelined ps AsServer st m a
+type ServerDualPipelined ps st m a = TP.PeerDualPipelined ps AsServer st m a
 
-pattern ServerAntiPipelined :: forall ps st m a.
+pattern ServerDualPipelined :: forall ps st m a.
                                ()
                             => forall apst apst'.
                                ()
                             => Sender ps apst apst' m
-                            -> Server ps (AntiPipelined apst apst' Z) st m a
-                            -> ServerAntiPipelined ps st m a
-pattern ServerAntiPipelined sender peer = TP.PeerAntiPipelined sender peer
+                            -> Server ps (DualPipelined apst apst' Z) st m a
+                            -> ServerDualPipelined ps st m a
+pattern ServerDualPipelined sender peer = TP.PeerDualPipelined sender peer
 
-{-# COMPLETE ServerAntiPipelined #-}
+{-# COMPLETE ServerDualPipelined #-}
 
 
 -- | Server role pattern for 'TP.Effect'.
@@ -106,7 +106,7 @@ pattern Yield :: forall ps pl st m a.
                  , StateTokenI st'
                  , StateAgency st ~ ServerAgency
                  , Outstanding pl ~ Z
-                 , AntiOutstanding pl ~ Z
+                 , DualOutstanding pl ~ Z
                  )
               => Message ps st st'
               -- ^ protocol message
@@ -138,7 +138,7 @@ pattern Done :: forall ps pl st m a.
              => ( StateTokenI st
                 , StateAgency st ~ NobodyAgency
                 , Outstanding pl ~ Z
-                , AntiOutstanding pl ~ Z
+                , DualOutstanding pl ~ Z
                 )
              => a
              -- ^ protocol return value
@@ -182,32 +182,32 @@ pattern Collect k' k = TP.Collect k' k
 {-# COMPLETE Effect, Yield, Await, Done, YieldPipelined, Collect  #-}
 
 
--- | Server role pattern for 'TP.YieldAntiPipelined'
+-- | Server role pattern for 'TP.YieldDualPipelined'
 --
-pattern YieldAntiPipelined :: forall ps st st' n m a.
+pattern YieldDualPipelined :: forall ps st st' n m a.
                               ()
                            => ( StateTokenI st
                               , StateTokenI st'
                               )
-                           => Server ps (AntiPipelined st st' (S n)) st' m a
+                           => Server ps (DualPipelined st st' (S n)) st' m a
                            -- ^ continuation, before or after sending
-                           -> Server ps (AntiPipelined st st'  n ) st  m a
-pattern YieldAntiPipelined k = TP.YieldAntiPipelined k
+                           -> Server ps (DualPipelined st st'  n ) st  m a
+pattern YieldDualPipelined k = TP.YieldDualPipelined k
 
 
--- | Server role pattern for 'TP.AntiCollect'
+-- | Server role pattern for 'TP.DualCollect'
 --
-pattern AntiCollect :: forall ps st apst apst' n m a.
+pattern DualCollect :: forall ps st apst apst' n m a.
                        ()
                     => StateTokenI st
-                    => Server ps (AntiPipelined apst apst'   n ) st m a
+                    => Server ps (DualPipelined apst apst'   n ) st m a
                     -- ^ continuation if the 'Sender' has already terminated
-                    -> Maybe (Server ps (AntiPipelined apst apst' (S n)) st m a)
+                    -> Maybe (Server ps (DualPipelined apst apst' (S n)) st m a)
                     -- ^ continuation if the 'Sender' may not have terminated
-                    -> Server ps (AntiPipelined apst apst' (S n)) st m a
-pattern AntiCollect k mk = TP.AntiCollect k mk
+                    -> Server ps (DualPipelined apst apst' (S n)) st m a
+pattern DualCollect k mk = TP.DualCollect k mk
 
-{-# COMPLETE Effect, Yield, Await, Done, YieldAntiPipelined, AntiCollect #-}
+{-# COMPLETE Effect, Yield, Await, Done, YieldDualPipelined, DualCollect #-}
 
 
 type Receiver ps st stdone m c = TP.Receiver ps AsServer st stdone m c

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -112,7 +112,7 @@ pattern Yield :: forall ps pl st m a.
               -> Server ps pl st' m a
               -- ^ continuation
               -> Server ps pl st  m a
-pattern Yield msg k = TP.Yield2 ReflServerAgency msg k
+pattern Yield msg k = TP.Yield ReflServerAgency msg k
 
 
 -- | Server role pattern for 'TP.Await'
@@ -160,7 +160,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Server ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Server ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.Yield2 ReflServerAgency msg (TP.AwaitPipelined receiver k)
+pattern YieldPipelined msg receiver k = TP.Yield ReflServerAgency msg (TP.AwaitPipelined receiver k)
 
 
 -- | Server role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -105,7 +105,6 @@ pattern Yield :: forall ps pl st m a.
                  ( StateTokenI st
                  , StateTokenI st'
                  , StateAgency st ~ ServerAgency
-                 , Outstanding pl ~ Z
                  , AntiOutstanding pl ~ Z
                  )
               => Message ps st st'
@@ -113,7 +112,7 @@ pattern Yield :: forall ps pl st m a.
               -> Server ps pl st' m a
               -- ^ continuation
               -> Server ps pl st  m a
-pattern Yield msg k = TP.Yield ReflServerAgency msg k
+pattern Yield msg k = TP.Yield2 ReflServerAgency msg k
 
 
 -- | Server role pattern for 'TP.Await'
@@ -161,7 +160,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Server ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Server ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.YieldPipelined ReflServerAgency msg receiver k
+pattern YieldPipelined msg receiver k = TP.Yield2 ReflServerAgency msg (TP.AwaitPipelined receiver k)
 
 
 -- | Server role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -78,6 +78,7 @@ pattern Yield :: forall ps pl st m a.
                  , StateTokenI st'
                  , StateAgency st ~ ServerAgency
                  , Outstanding pl ~ Z
+                 , AntiOutstanding pl ~ Z
                  )
               => Message ps st st'
               -- ^ protocol message
@@ -109,6 +110,7 @@ pattern Done :: forall ps pl st m a.
              => ( StateTokenI st
                 , StateAgency st ~ NobodyAgency
                 , Outstanding pl ~ Z
+                , AntiOutstanding pl ~ Z
                 )
              => a
              -- ^ protocol return value

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -112,7 +112,7 @@ pattern Yield :: forall ps pl st m a.
               -> Server ps pl st' m a
               -- ^ continuation
               -> Server ps pl st  m a
-pattern Yield msg k = TP.Yield ReflServerAgency msg k
+pattern Yield msg k = TP.Yield2 ReflServerAgency msg k
 
 
 -- | Server role pattern for 'TP.Await'
@@ -160,7 +160,7 @@ pattern YieldPipelined :: forall ps st n c m a.
                        -> Server ps (Pipelined (S n) c) st'' m a
                        -- ^ continuation
                        -> Server ps (Pipelined    n  c)  st   m a
-pattern YieldPipelined msg receiver k = TP.Yield ReflServerAgency msg (TP.AwaitPipelined receiver k)
+pattern YieldPipelined msg receiver k = TP.Yield2 ReflServerAgency msg (TP.AwaitPipelined receiver k)
 
 
 -- | Server role pattern for 'TP.Collect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -188,7 +188,6 @@ pattern YieldAntiPipelined :: forall ps st st' n m a.
                               ()
                            => ( StateTokenI st
                               , StateTokenI st'
-                              , ActiveState st
                               )
                            => Server ps (AntiPipelined st st' (S n)) st' m a
                            -- ^ continuation, before or after sending

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -188,12 +188,12 @@ pattern YieldAntiPipelined :: forall ps st st' n m a.
                               ()
                            => ( StateTokenI st
                               , StateTokenI st'
-                              , StateAgency st ~ ServerAgency
+                              , ActiveState st
                               )
                            => Server ps (AntiPipelined st st' (S n)) st' m a
                            -- ^ continuation, before or after sending
                            -> Server ps (AntiPipelined st st'  n ) st  m a
-pattern YieldAntiPipelined k = TP.YieldAntiPipelined ReflServerAgency k
+pattern YieldAntiPipelined k = TP.YieldAntiPipelined k
 
 
 -- | Server role pattern for 'TP.AntiCollect'

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -37,7 +37,7 @@ import Network.TypedProtocol.Peer qualified as TP
 
 
 type Server :: forall ps
-            -> IsPipelined
+            -> IsPipelined ps
             -> ps
             -> (Type -> Type)
             -> Type

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -14,17 +14,28 @@ module Network.TypedProtocol.Peer.Server
   , pattern Done
   , pattern YieldPipelined
   , pattern Collect
+  , pattern YieldAntiPipelined
+  , pattern AntiCollect
     -- * Receiver type alias and its pattern synonyms
   , Receiver
   , pattern ReceiverEffect
   , pattern ReceiverAwait
   , pattern ReceiverDone
+    -- * Sender type alias and its pattern synonyms
+  , Sender
+  , pattern SenderEffect
+  , pattern SenderYield
+  , pattern SenderDone
     -- * ServerPipelined type alias and its pattern synonym
   , ServerPipelined
   , TP.PeerPipelined (ServerPipelined, runServerPipelined)
+    -- * ServerAntiPipelined type alias and its pattern synonym
+  , ServerAntiPipelined
+  , pattern ServerAntiPipelined
     -- * re-exports
   , IsPipelined (..)
   , Outstanding
+  , AntiOutstanding
   , N (..)
   , Nat (..)
   ) where
@@ -58,6 +69,23 @@ pattern ServerPipelined :: forall ps st m a.
 pattern ServerPipelined { runServerPipelined } = TP.PeerPipelined runServerPipelined
 
 {-# COMPLETE ServerPipelined #-}
+
+
+-- | A description of a peer that engages in a protocol in an anti-pipelined
+-- fashion (ie non-blocking sends).
+--
+type ServerAntiPipelined ps st m a = TP.PeerAntiPipelined ps AsServer st m a
+
+pattern ServerAntiPipelined :: forall ps st m a.
+                               ()
+                            => forall apst apst'.
+                               ()
+                            => Sender ps apst apst' m
+                            -> Server ps (AntiPipelined apst apst' Z) st m a
+                            -> ServerAntiPipelined ps st m a
+pattern ServerAntiPipelined sender peer = TP.PeerAntiPipelined sender peer
+
+{-# COMPLETE ServerAntiPipelined #-}
 
 
 -- | Server role pattern for 'TP.Effect'.
@@ -154,6 +182,35 @@ pattern Collect k' k = TP.Collect k' k
 {-# COMPLETE Effect, Yield, Await, Done, YieldPipelined, Collect  #-}
 
 
+-- | Server role pattern for 'TP.YieldAntiPipelined'
+--
+pattern YieldAntiPipelined :: forall ps st st' n m a.
+                              ()
+                           => ( StateTokenI st
+                              , StateTokenI st'
+                              , StateAgency st ~ ServerAgency
+                              )
+                           => Server ps (AntiPipelined st st' (S n)) st' m a
+                           -- ^ continuation, before or after sending
+                           -> Server ps (AntiPipelined st st'  n ) st  m a
+pattern YieldAntiPipelined k = TP.YieldAntiPipelined ReflServerAgency k
+
+
+-- | Server role pattern for 'TP.AntiCollect'
+--
+pattern AntiCollect :: forall ps st apst apst' n m a.
+                       ()
+                    => StateTokenI st
+                    => Server ps (AntiPipelined apst apst'   n ) st m a
+                    -- ^ continuation if the 'Sender' has already terminated
+                    -> Maybe (Server ps (AntiPipelined apst apst' (S n)) st m a)
+                    -- ^ continuation if the 'Sender' may not have terminated
+                    -> Server ps (AntiPipelined apst apst' (S n)) st m a
+pattern AntiCollect k mk = TP.AntiCollect k mk
+
+{-# COMPLETE Effect, Yield, Await, Done, YieldAntiPipelined, AntiCollect #-}
+
+
 type Receiver ps st stdone m c = TP.Receiver ps AsServer st stdone m c
 
 pattern ReceiverEffect :: forall ps st stdone m c.
@@ -179,3 +236,29 @@ pattern ReceiverDone :: forall ps stdone m c.
 pattern ReceiverDone c = TP.ReceiverDone c
 
 {-# COMPLETE ReceiverEffect, ReceiverAwait, ReceiverDone #-}
+
+
+type Sender ps st stdone m = TP.Sender ps AsServer st stdone m
+
+pattern SenderEffect :: forall ps st stdone m.
+                        m (Sender ps st stdone m)
+                     -> Sender ps st stdone m
+pattern SenderEffect k = TP.SenderEffect k
+
+pattern SenderYield :: forall ps st stdone m.
+                       ()
+                    => forall st'.
+                       ( StateTokenI st
+                       , StateTokenI st'
+                       , StateAgency st ~ ServerAgency
+                       )
+                    => Message ps st st'
+                    -> Sender ps st' stdone m
+                    -> Sender ps st  stdone m
+pattern SenderYield msg k = TP.SenderYield ReflServerAgency msg k
+
+pattern SenderDone :: forall ps stdone m.
+                      Sender ps stdone stdone m
+pattern SenderDone = TP.SenderDone
+
+{-# COMPLETE SenderEffect, SenderYield, SenderDone #-}

--- a/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Peer/Server.hs
@@ -14,8 +14,8 @@ module Network.TypedProtocol.Peer.Server
   , pattern Done
   , pattern YieldPipelined
   , pattern Collect
-  , pattern YieldDualPipelined
-  , pattern DualCollect
+  , pattern YieldDualPipelined1
+  , pattern DualCollect1
     -- * Receiver type alias and its pattern synonyms
   , Receiver
   , pattern ReceiverEffect
@@ -29,9 +29,9 @@ module Network.TypedProtocol.Peer.Server
     -- * ServerPipelined type alias and its pattern synonym
   , ServerPipelined
   , TP.PeerPipelined (ServerPipelined, runServerPipelined)
-    -- * ServerDualPipelined type alias and its pattern synonym
-  , ServerDualPipelined
-  , pattern ServerDualPipelined
+    -- * ServerDualPipelined1 type alias and its pattern synonym
+  , ServerDualPipelined1
+  , pattern ServerDualPipelined1
     -- * re-exports
   , IsPipelined (..)
   , Outstanding
@@ -74,18 +74,18 @@ pattern ServerPipelined { runServerPipelined } = TP.PeerPipelined runServerPipel
 -- | A description of a peer that engages in a protocol in an anti-pipelined
 -- fashion (ie non-blocking sends).
 --
-type ServerDualPipelined ps st m a = TP.PeerDualPipelined ps AsServer st m a
+type ServerDualPipelined1 ps st m a = TP.PeerDualPipelined1 ps AsServer st m a
 
-pattern ServerDualPipelined :: forall ps st m a.
+pattern ServerDualPipelined1 :: forall ps st m a.
                                ()
                             => forall apst apst'.
                                ()
                             => Sender ps apst apst' m
-                            -> Server ps (DualPipelined apst apst' Z) st m a
-                            -> ServerDualPipelined ps st m a
-pattern ServerDualPipelined sender peer = TP.PeerDualPipelined sender peer
+                            -> Server ps (DualPipelined1 apst apst' Z) st m a
+                            -> ServerDualPipelined1 ps st m a
+pattern ServerDualPipelined1 sender peer = TP.PeerDualPipelined1 sender peer
 
-{-# COMPLETE ServerDualPipelined #-}
+{-# COMPLETE ServerDualPipelined1 #-}
 
 
 -- | Server role pattern for 'TP.Effect'.
@@ -182,32 +182,32 @@ pattern Collect k' k = TP.Collect k' k
 {-# COMPLETE Effect, Yield, Await, Done, YieldPipelined, Collect  #-}
 
 
--- | Server role pattern for 'TP.YieldDualPipelined'
+-- | Server role pattern for 'TP.YieldDualPipelined1'
 --
-pattern YieldDualPipelined :: forall ps st st' n m a.
+pattern YieldDualPipelined1 :: forall ps st st' n m a.
                               ()
                            => ( StateTokenI st
                               , StateTokenI st'
                               )
-                           => Server ps (DualPipelined st st' (S n)) st' m a
+                           => Server ps (DualPipelined1 st st' (S n)) st' m a
                            -- ^ continuation, before or after sending
-                           -> Server ps (DualPipelined st st'  n ) st  m a
-pattern YieldDualPipelined k = TP.YieldDualPipelined k
+                           -> Server ps (DualPipelined1 st st'  n ) st  m a
+pattern YieldDualPipelined1 k = TP.YieldDualPipelined1 k
 
 
--- | Server role pattern for 'TP.DualCollect'
+-- | Server role pattern for 'TP.DualCollect1'
 --
-pattern DualCollect :: forall ps st apst apst' n m a.
+pattern DualCollect1 :: forall ps st apst apst' n m a.
                        ()
                     => StateTokenI st
-                    => Server ps (DualPipelined apst apst'   n ) st m a
+                    => Server ps (DualPipelined1 apst apst'   n ) st m a
                     -- ^ continuation if the 'Sender' has already terminated
-                    -> Maybe (Server ps (DualPipelined apst apst' (S n)) st m a)
+                    -> Maybe (Server ps (DualPipelined1 apst apst' (S n)) st m a)
                     -- ^ continuation if the 'Sender' may not have terminated
-                    -> Server ps (DualPipelined apst apst' (S n)) st m a
-pattern DualCollect k mk = TP.DualCollect k mk
+                    -> Server ps (DualPipelined1 apst apst' (S n)) st m a
+pattern DualCollect1 k mk = TP.DualCollect1 k mk
 
-{-# COMPLETE Effect, Yield, Await, Done, YieldDualPipelined, DualCollect #-}
+{-# COMPLETE Effect, Yield, Await, Done, YieldDualPipelined1, DualCollect1 #-}
 
 
 type Receiver ps st stdone m c = TP.Receiver ps AsServer st stdone m c

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -76,12 +76,12 @@ connect = go
 
     go (Effect a )      b              = a >>= \a' -> go a' b
     go  a              (Effect b)      = b >>= \b' -> go a  b'
-    go (Yield2 _ msg a) (Await _ b)     = go  a     (b msg)
-    go (Await _ a)     (Yield2 _ msg b) = go (a msg) b
+    go (Yield _ msg a) (Await _ b)     = go  a     (b msg)
+    go (Await _ a)     (Yield _ msg b) = go (a msg) b
 
     -- By appealing to the proofs about agency for this protocol we can
     -- show that these other cases are impossible
-    go (Yield2 reflA _ _) (Yield2 reflB _ _) =
+    go (Yield reflA _ _) (Yield reflB _ _) =
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -89,7 +89,7 @@ connect = go
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
-    go (Done  reflA _) (Yield2 reflB _ _)   =
+    go (Done  reflA _) (Yield reflB _ _)   =
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
@@ -97,7 +97,7 @@ connect = go
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
-    go (Yield2 reflA _ _) (Done reflB _)    =
+    go (Yield reflA _ _) (Done reflB _)    =
       case terminationLemma_1 singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -162,9 +162,9 @@ forgetPipelined cs0 (PeerPipelined peer) = goSender EmptyQ cs0 peer
 
     goSender EmptyQ _cs (Done           refl     k) = Done refl k
     goSender q       cs (Effect                  k) = Effect (goSender q cs <$> k)
-    goSender q       cs (Yield2         refl m   k) = Yield2 refl m (goSender q cs k)
+    goSender q       cs (Yield          refl m   k) = Yield refl m (goSender q cs k)
     goSender q       cs (Await          refl     k) = Await refl   (goSender q cs <$> k)
-    goSender q       cs (AwaitPipelined      r   k) = goReceiver q cs k r
+    goSender q       cs (YieldPipelined refl m r k) = Yield refl m (goReceiver q cs k r)
     goSender q (True:cs')       (Collect (Just k) _) = goSender q cs' k
     goSender (ConsQ x q) (_:cs) (Collect _ k)        = goSender q cs (k x)
     goSender (ConsQ x q) cs@[]  (Collect _ k)        = goSender q cs (k x)
@@ -200,7 +200,7 @@ promoteToPipelined p = PeerPipelined (go p)
           Peer ps pr NonPipelined    st' m a
        -> Peer ps pr (Pipelined Z c) st' m a
     go (Effect k)         = Effect $ go <$> k
-    go (Yield2 refl msg k) = Yield2 refl msg (go k)
+    go (Yield refl msg k) = Yield refl msg (go k)
     go (Await refl k)     = Await refl (go . k)
     go (Done refl k)      = Done refl k
 
@@ -271,7 +271,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
            -> Peer ps pr 'NonPipelined                 st' m a
     goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
     goPeer _  (Done  refl           k) = Done refl k
-    goPeer cs (Yield2 refl m         k) = Yield2 refl m (goPeer cs k)
+    goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
     goPeer cs (YieldAntiPipelined   k) = goSender sender (goPeer cs k)
     goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
@@ -284,7 +284,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
              -> Peer   ps pr 'NonPipelined sst   m a
     goSender  SenderDone             k = k
     goSender (SenderEffect       ks) k = Effect ((`goSender` k) <$> ks)
-    goSender (SenderYield refl m ks) k = Yield2 refl m (goSender ks k)
+    goSender (SenderYield refl m ks) k = Yield refl m (goSender ks k)
 
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
@@ -306,7 +306,7 @@ promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
           Peer ps pr 'NonPipelined            st' m a
        -> Peer ps pr ('AntiPipelined st st 'Z) st' m a
     go (Effect         k) = Effect (go <$> k)
-    go (Yield2 refl m   k) = Yield2 refl m (go k)
+    go (Yield refl m   k) = Yield refl m (go k)
     go (Await refl     k) = Await refl (go . k)
     go (Done  refl     k) = Done refl k
 

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -12,16 +12,16 @@ module Network.TypedProtocol.Proofs
   ( -- * Connect proofs
     connect
   , connectPipelined
-  , connectAntiPipelined
+  , connectDualPipelined
   , TerminalStates (..)
     -- * Pipelining proofs
     -- | Additional proofs specific to the pipelining features
   , forgetPipelined
   , promoteToPipelined
-    -- * Anti-pipelining proofs
+    -- * Dual-pipelining proofs
     -- | Additional proofs specific to the anti-pipelining features
-  , forgetAntiPipelined
-  , promoteToAntiPipelined
+  , forgetDualPipelined
+  , promoteToDualPipelined
     -- ** Pipeline proof helpers
   , Queue (..)
   , enqueue
@@ -237,7 +237,7 @@ connectPipelined csA a b =
 
 
 --
--- Remove Anti-Pipelining
+-- Remove Dual-Pipelining
 --
 
 
@@ -245,38 +245,38 @@ connectPipelined csA a b =
 -- peers. This is the anti-pipelining analogue of 'forgetPipelined'.
 --
 -- Where 'forgetPipelined' inlines each deferred 'Receiver' at the point it is
--- collected, this inlines the single 'Sender' at each 'YieldAntiPipelined':
+-- collected, this inlines the single 'Sender' at each 'YieldDualPipelined':
 -- the messages the sender thread would have sent asynchronously are instead
 -- sent synchronously, at the point the peer delegated them.
 --
 -- Dually to 'forgetPipelined', the @[Bool]@ chooses the interleaving at each
--- 'AntiCollect': a @True@ pretends the delegated 'Sender' has not terminated
+-- 'DualCollect': a @True@ pretends the delegated 'Sender' has not terminated
 -- yet, so the peer takes its non-blocking continuation (when it has one) and
 -- leaves the send outstanding; a @False@ (or @[]@) collects.
 --
-forgetAntiPipelined
+forgetDualPipelined
   :: forall ps (pr :: PeerRole) (st :: ps) m a.
      Functor m
   => [Bool]
-  -- ^ interleaving choices for anti-pipelining allowed by `AntiCollect` primitive.
+  -- ^ interleaving choices for anti-pipelining allowed by `DualCollect` primitive.
   -- False values or `[]` give no anti-pipelining.
-  -> PeerAntiPipelined ps pr              st m a
+  -> PeerDualPipelined ps pr              st m a
   -> Peer              ps pr NonPipelined st m a
-forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m) peer0) =
+forgetDualPipelined cs0 (PeerDualPipelined (sender :: Sender ps pr apst apst' m) peer0) =
     goPeer cs0 peer0
   where
     goPeer :: forall st' n.
               [Bool]
-           -> Peer ps pr ('AntiPipelined apst apst' n) st' m a
+           -> Peer ps pr ('DualPipelined apst apst' n) st' m a
            -> Peer ps pr 'NonPipelined                 st' m a
     goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
     goPeer _  (Done  refl           k) = Done refl k
     goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
-    goPeer cs (YieldAntiPipelined   k) = goSender sender (goPeer cs k)
-    goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
-    goPeer (_:cs)     (AntiCollect k _)        = goPeer cs  k
-    goPeer cs@[]      (AntiCollect k _)        = goPeer cs  k
+    goPeer cs (YieldDualPipelined   k) = goSender sender (goPeer cs k)
+    goPeer (True:cs') (DualCollect _ (Just k)) = goPeer cs' k
+    goPeer (_:cs)     (DualCollect k _)        = goPeer cs  k
+    goPeer cs@[]      (DualCollect k _)        = goPeer cs  k
 
     goSender :: forall sst.
                 Sender ps pr sst apst' m
@@ -289,22 +289,22 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
 --
--- This is a right inverse of 'forgetAntiPipelined', e.g.
+-- This is a right inverse of 'forgetDualPipelined', e.g.
 --
--- >>> forgetAntiPipelined . promoteToAntiPipelined = id
+-- >>> forgetDualPipelined . promoteToDualPipelined = id
 --
-promoteToAntiPipelined
+promoteToDualPipelined
   :: forall ps (pr :: PeerRole) (st :: ps) m a.
      Functor m
   => Peer              ps pr NonPipelined st m a
   -- ^ a peer
-  -> PeerAntiPipelined ps pr              st m a
+  -> PeerDualPipelined ps pr              st m a
   -- ^ an anti-pipelined peer
-promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
+promoteToDualPipelined p = PeerDualPipelined SenderDone (go p)
   where
     go :: forall st'.
           Peer ps pr 'NonPipelined            st' m a
-       -> Peer ps pr ('AntiPipelined st st 'Z) st' m a
+       -> Peer ps pr ('DualPipelined st st 'Z) st' m a
     go (Effect         k) = Effect (go <$> k)
     go (Yield refl m   k) = Yield refl m (go k)
     go (Await refl     k) = Await refl (go . k)
@@ -313,20 +313,20 @@ promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
 
 -- | Analogous to 'connectPipelined' but for anti-pipelined peers.
 --
-connectAntiPipelined
+connectDualPipelined
   :: forall ps (pr :: PeerRole)
                (st :: ps) m a b.
        (Monad m, SingI pr)
     => [Bool]
     -- ^ an interleaving
-    -> PeerAntiPipelined ps             pr               st m a
+    -> PeerDualPipelined ps             pr               st m a
     -- ^ an anti-pipelined peer
     -> Peer              ps (FlipAgency pr) NonPipelined st m b
     -- ^ a non-pipelined peer with flipped agency
     -> m (a, b, TerminalStates ps)
     -- ^ peers results and an evidence of their termination
-connectAntiPipelined cs a b =
-    connect (forgetAntiPipelined cs a) b
+connectDualPipelined cs a b =
+    connect (forgetDualPipelined cs a) b
 
 -- | A reference specification for interleaving of requests and responses
 -- with pipelining, where the environment can choose whether a response is

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -12,7 +12,7 @@ module Network.TypedProtocol.Proofs
   ( -- * Connect proofs
     connect
   , connectPipelined
-  , connectDualPipelined
+  , connectDualPipelined1
   , TerminalStates (..)
     -- * Pipelining proofs
     -- | Additional proofs specific to the pipelining features
@@ -20,8 +20,8 @@ module Network.TypedProtocol.Proofs
   , promoteToPipelined
     -- * Dual-pipelining proofs
     -- | Additional proofs specific to the anti-pipelining features
-  , forgetDualPipelined
-  , promoteToDualPipelined
+  , forgetDualPipelined1
+  , promoteToDualPipelined1
     -- ** Pipeline proof helpers
   , Queue (..)
   , enqueue
@@ -245,38 +245,38 @@ connectPipelined csA a b =
 -- peers. This is the anti-pipelining analogue of 'forgetPipelined'.
 --
 -- Where 'forgetPipelined' inlines each deferred 'Receiver' at the point it is
--- collected, this inlines the single 'Sender' at each 'YieldDualPipelined':
+-- collected, this inlines the single 'Sender' at each 'YieldDualPipelined1':
 -- the messages the sender thread would have sent asynchronously are instead
 -- sent synchronously, at the point the peer delegated them.
 --
 -- Dually to 'forgetPipelined', the @[Bool]@ chooses the interleaving at each
--- 'DualCollect': a @True@ pretends the delegated 'Sender' has not terminated
+-- 'DualCollect1': a @True@ pretends the delegated 'Sender' has not terminated
 -- yet, so the peer takes its non-blocking continuation (when it has one) and
 -- leaves the send outstanding; a @False@ (or @[]@) collects.
 --
-forgetDualPipelined
+forgetDualPipelined1
   :: forall ps (pr :: PeerRole) (st :: ps) m a.
      Functor m
   => [Bool]
-  -- ^ interleaving choices for anti-pipelining allowed by `DualCollect` primitive.
+  -- ^ interleaving choices for anti-pipelining allowed by `DualCollect1` primitive.
   -- False values or `[]` give no anti-pipelining.
-  -> PeerDualPipelined ps pr              st m a
+  -> PeerDualPipelined1 ps pr              st m a
   -> Peer              ps pr NonPipelined st m a
-forgetDualPipelined cs0 (PeerDualPipelined (sender :: Sender ps pr apst apst' m) peer0) =
+forgetDualPipelined1 cs0 (PeerDualPipelined1 (sender :: Sender ps pr apst apst' m) peer0) =
     goPeer cs0 peer0
   where
     goPeer :: forall st' n.
               [Bool]
-           -> Peer ps pr ('DualPipelined apst apst' n) st' m a
+           -> Peer ps pr ('DualPipelined1 apst apst' n) st' m a
            -> Peer ps pr 'NonPipelined                 st' m a
     goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
     goPeer _  (Done  refl           k) = Done refl k
     goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
-    goPeer cs (YieldDualPipelined   k) = goSender sender (goPeer cs k)
-    goPeer (True:cs') (DualCollect _ (Just k)) = goPeer cs' k
-    goPeer (_:cs)     (DualCollect k _)        = goPeer cs  k
-    goPeer cs@[]      (DualCollect k _)        = goPeer cs  k
+    goPeer cs (YieldDualPipelined1   k) = goSender sender (goPeer cs k)
+    goPeer (True:cs') (DualCollect1 _ (Just k)) = goPeer cs' k
+    goPeer (_:cs)     (DualCollect1 k _)        = goPeer cs  k
+    goPeer cs@[]      (DualCollect1 k _)        = goPeer cs  k
 
     goSender :: forall sst.
                 Sender ps pr sst apst' m
@@ -289,22 +289,22 @@ forgetDualPipelined cs0 (PeerDualPipelined (sender :: Sender ps pr apst apst' m)
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
 --
--- This is a right inverse of 'forgetDualPipelined', e.g.
+-- This is a right inverse of 'forgetDualPipelined1', e.g.
 --
--- >>> forgetDualPipelined . promoteToDualPipelined = id
+-- >>> forgetDualPipelined1 . promoteToDualPipelined1 = id
 --
-promoteToDualPipelined
+promoteToDualPipelined1
   :: forall ps (pr :: PeerRole) (st :: ps) m a.
      Functor m
   => Peer              ps pr NonPipelined st m a
   -- ^ a peer
-  -> PeerDualPipelined ps pr              st m a
+  -> PeerDualPipelined1 ps pr              st m a
   -- ^ an anti-pipelined peer
-promoteToDualPipelined p = PeerDualPipelined SenderDone (go p)
+promoteToDualPipelined1 p = PeerDualPipelined1 SenderDone (go p)
   where
     go :: forall st'.
           Peer ps pr 'NonPipelined            st' m a
-       -> Peer ps pr ('DualPipelined st st 'Z) st' m a
+       -> Peer ps pr ('DualPipelined1 st st 'Z) st' m a
     go (Effect         k) = Effect (go <$> k)
     go (Yield refl m   k) = Yield refl m (go k)
     go (Await refl     k) = Await refl (go . k)
@@ -313,20 +313,20 @@ promoteToDualPipelined p = PeerDualPipelined SenderDone (go p)
 
 -- | Analogous to 'connectPipelined' but for anti-pipelined peers.
 --
-connectDualPipelined
+connectDualPipelined1
   :: forall ps (pr :: PeerRole)
                (st :: ps) m a b.
        (Monad m, SingI pr)
     => [Bool]
     -- ^ an interleaving
-    -> PeerDualPipelined ps             pr               st m a
+    -> PeerDualPipelined1 ps             pr               st m a
     -- ^ an anti-pipelined peer
     -> Peer              ps (FlipAgency pr) NonPipelined st m b
     -- ^ a non-pipelined peer with flipped agency
     -> m (a, b, TerminalStates ps)
     -- ^ peers results and an evidence of their termination
-connectDualPipelined cs a b =
-    connect (forgetDualPipelined cs a) b
+connectDualPipelined1 cs a b =
+    connect (forgetDualPipelined1 cs a) b
 
 -- | A reference specification for interleaving of requests and responses
 -- with pipelining, where the environment can choose whether a response is

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -213,6 +213,11 @@ promoteToPipelined p = PeerPipelined (go p)
 -- to more results outstanding. This can also be interpreted as a greater
 -- pipeline depth, or more messages in-flight.
 --
+-- The @[Bool]@ stream permits exploration of some interleavings, but not
+-- all. In particular, it does not explore different possible interleavings of
+-- the 'ReceiverEffect' with the 'Pipelined' peer's 'Effect's: the full
+-- 'Receiver' is always executed immediately first.
+--
 -- This can be exercised using a QuickCheck style generator.
 --
 connectPipelined

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -76,12 +76,12 @@ connect = go
 
     go (Effect a )      b              = a >>= \a' -> go a' b
     go  a              (Effect b)      = b >>= \b' -> go a  b'
-    go (Yield _ msg a) (Await _ b)     = go  a     (b msg)
-    go (Await _ a)     (Yield _ msg b) = go (a msg) b
+    go (Yield2 _ msg a) (Await _ b)     = go  a     (b msg)
+    go (Await _ a)     (Yield2 _ msg b) = go (a msg) b
 
     -- By appealing to the proofs about agency for this protocol we can
     -- show that these other cases are impossible
-    go (Yield reflA _ _) (Yield reflB _ _) =
+    go (Yield2 reflA _ _) (Yield2 reflB _ _) =
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -89,7 +89,7 @@ connect = go
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
-    go (Done  reflA _) (Yield reflB _ _)   =
+    go (Done  reflA _) (Yield2 reflB _ _)   =
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
@@ -97,7 +97,7 @@ connect = go
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
-    go (Yield reflA _ _) (Done reflB _)    =
+    go (Yield2 reflA _ _) (Done reflB _)    =
       case terminationLemma_1 singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -162,7 +162,7 @@ forgetPipelined cs0 (PeerPipelined peer) = goSender EmptyQ cs0 peer
 
     goSender EmptyQ _cs (Done           refl     k) = Done refl k
     goSender q       cs (Effect                  k) = Effect (goSender q cs <$> k)
-    goSender q       cs (Yield         refl m   k) = Yield refl m (goSender q cs k)
+    goSender q       cs (Yield2         refl m   k) = Yield2 refl m (goSender q cs k)
     goSender q       cs (Await          refl     k) = Await refl   (goSender q cs <$> k)
     goSender q       cs (AwaitPipelined      r   k) = goReceiver q cs k r
     goSender q (True:cs')       (Collect (Just k) _) = goSender q cs' k
@@ -200,7 +200,7 @@ promoteToPipelined p = PeerPipelined (go p)
           Peer ps pr NonPipelined    st' m a
        -> Peer ps pr (Pipelined Z c) st' m a
     go (Effect k)         = Effect $ go <$> k
-    go (Yield refl msg k) = Yield refl msg (go k)
+    go (Yield2 refl msg k) = Yield2 refl msg (go k)
     go (Await refl k)     = Await refl (go . k)
     go (Done refl k)      = Done refl k
 
@@ -271,7 +271,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
            -> Peer ps pr 'NonPipelined                 st' m a
     goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
     goPeer _  (Done  refl           k) = Done refl k
-    goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
+    goPeer cs (Yield2 refl m         k) = Yield2 refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
     goPeer cs (YieldAntiPipelined   k) = goSender sender (goPeer cs k)
     goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
@@ -284,7 +284,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
              -> Peer   ps pr 'NonPipelined sst   m a
     goSender  SenderDone             k = k
     goSender (SenderEffect       ks) k = Effect ((`goSender` k) <$> ks)
-    goSender (SenderYield refl m ks) k = Yield refl m (goSender ks k)
+    goSender (SenderYield refl m ks) k = Yield2 refl m (goSender ks k)
 
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
@@ -306,7 +306,7 @@ promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
           Peer ps pr 'NonPipelined            st' m a
        -> Peer ps pr ('AntiPipelined st st 'Z) st' m a
     go (Effect         k) = Effect (go <$> k)
-    go (Yield refl m   k) = Yield refl m (go k)
+    go (Yield2 refl m   k) = Yield2 refl m (go k)
     go (Await refl     k) = Await refl (go . k)
     go (Done  refl     k) = Done refl k
 

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -76,12 +76,12 @@ connect = go
 
     go (Effect a )      b              = a >>= \a' -> go a' b
     go  a              (Effect b)      = b >>= \b' -> go a  b'
-    go (Yield2 _ msg a) (Await _ b)     = go  a     (b msg)
-    go (Await _ a)     (Yield2 _ msg b) = go (a msg) b
+    go (Yield _ msg a) (Await _ b)     = go  a     (b msg)
+    go (Await _ a)     (Yield _ msg b) = go (a msg) b
 
     -- By appealing to the proofs about agency for this protocol we can
     -- show that these other cases are impossible
-    go (Yield2 reflA _ _) (Yield2 reflB _ _) =
+    go (Yield reflA _ _) (Yield reflB _ _) =
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -89,7 +89,7 @@ connect = go
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
-    go (Done  reflA _) (Yield2 reflB _ _)   =
+    go (Done  reflA _) (Yield reflB _ _)   =
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
@@ -97,7 +97,7 @@ connect = go
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
-    go (Yield2 reflA _ _) (Done reflB _)    =
+    go (Yield reflA _ _) (Done reflB _)    =
       case terminationLemma_1 singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -162,7 +162,7 @@ forgetPipelined cs0 (PeerPipelined peer) = goSender EmptyQ cs0 peer
 
     goSender EmptyQ _cs (Done           refl     k) = Done refl k
     goSender q       cs (Effect                  k) = Effect (goSender q cs <$> k)
-    goSender q       cs (Yield2         refl m   k) = Yield2 refl m (goSender q cs k)
+    goSender q       cs (Yield         refl m   k) = Yield refl m (goSender q cs k)
     goSender q       cs (Await          refl     k) = Await refl   (goSender q cs <$> k)
     goSender q       cs (AwaitPipelined      r   k) = goReceiver q cs k r
     goSender q (True:cs')       (Collect (Just k) _) = goSender q cs' k
@@ -200,7 +200,7 @@ promoteToPipelined p = PeerPipelined (go p)
           Peer ps pr NonPipelined    st' m a
        -> Peer ps pr (Pipelined Z c) st' m a
     go (Effect k)         = Effect $ go <$> k
-    go (Yield2 refl msg k) = Yield2 refl msg (go k)
+    go (Yield refl msg k) = Yield refl msg (go k)
     go (Await refl k)     = Await refl (go . k)
     go (Done refl k)      = Done refl k
 
@@ -271,7 +271,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
            -> Peer ps pr 'NonPipelined                 st' m a
     goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
     goPeer _  (Done  refl           k) = Done refl k
-    goPeer cs (Yield2 refl m         k) = Yield2 refl m (goPeer cs k)
+    goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
     goPeer cs (YieldAntiPipelined   k) = goSender sender (goPeer cs k)
     goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
@@ -284,7 +284,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
              -> Peer   ps pr 'NonPipelined sst   m a
     goSender  SenderDone             k = k
     goSender (SenderEffect       ks) k = Effect ((`goSender` k) <$> ks)
-    goSender (SenderYield refl m ks) k = Yield2 refl m (goSender ks k)
+    goSender (SenderYield refl m ks) k = Yield refl m (goSender ks k)
 
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
@@ -306,7 +306,7 @@ promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
           Peer ps pr 'NonPipelined            st' m a
        -> Peer ps pr ('AntiPipelined st st 'Z) st' m a
     go (Effect         k) = Effect (go <$> k)
-    go (Yield2 refl m   k) = Yield2 refl m (go k)
+    go (Yield refl m   k) = Yield refl m (go k)
     go (Await refl     k) = Await refl (go . k)
     go (Done  refl     k) = Done refl k
 

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -76,12 +76,12 @@ connect = go
 
     go (Effect a )      b              = a >>= \a' -> go a' b
     go  a              (Effect b)      = b >>= \b' -> go a  b'
-    go (Yield _ msg a) (Await _ b)     = go  a     (b msg)
-    go (Await _ a)     (Yield _ msg b) = go (a msg) b
+    go (Yield2 _ msg a) (Await _ b)     = go  a     (b msg)
+    go (Await _ a)     (Yield2 _ msg b) = go (a msg) b
 
     -- By appealing to the proofs about agency for this protocol we can
     -- show that these other cases are impossible
-    go (Yield reflA _ _) (Yield reflB _ _) =
+    go (Yield2 reflA _ _) (Yield2 reflB _ _) =
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -89,7 +89,7 @@ connect = go
       case exclusionLemma_ClientAndServerHaveAgency singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
-    go (Done  reflA _) (Yield reflB _ _)   =
+    go (Done  reflA _) (Yield2 reflB _ _)   =
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
@@ -97,7 +97,7 @@ connect = go
       case terminationLemma_2 singPeerRole reflB reflA of
         ReflNobodyHasAgency -> case reflB of {}
 
-    go (Yield reflA _ _) (Done reflB _)    =
+    go (Yield2 reflA _ _) (Done reflB _)    =
       case terminationLemma_1 singPeerRole reflA reflB of
         ReflNobodyHasAgency -> case reflA of {}
 
@@ -162,9 +162,9 @@ forgetPipelined cs0 (PeerPipelined peer) = goSender EmptyQ cs0 peer
 
     goSender EmptyQ _cs (Done           refl     k) = Done refl k
     goSender q       cs (Effect                  k) = Effect (goSender q cs <$> k)
-    goSender q       cs (Yield          refl m   k) = Yield refl m (goSender q cs k)
+    goSender q       cs (Yield2         refl m   k) = Yield2 refl m (goSender q cs k)
     goSender q       cs (Await          refl     k) = Await refl   (goSender q cs <$> k)
-    goSender q       cs (YieldPipelined refl m r k) = Yield refl m (goReceiver q cs k r)
+    goSender q       cs (AwaitPipelined      r   k) = goReceiver q cs k r
     goSender q (True:cs')       (Collect (Just k) _) = goSender q cs' k
     goSender (ConsQ x q) (_:cs) (Collect _ k)        = goSender q cs (k x)
     goSender (ConsQ x q) cs@[]  (Collect _ k)        = goSender q cs (k x)
@@ -200,7 +200,7 @@ promoteToPipelined p = PeerPipelined (go p)
           Peer ps pr NonPipelined    st' m a
        -> Peer ps pr (Pipelined Z c) st' m a
     go (Effect k)         = Effect $ go <$> k
-    go (Yield refl msg k) = Yield refl msg (go k)
+    go (Yield2 refl msg k) = Yield2 refl msg (go k)
     go (Await refl k)     = Await refl (go . k)
     go (Done refl k)      = Done refl k
 
@@ -271,7 +271,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
            -> Peer ps pr 'NonPipelined                 st' m a
     goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
     goPeer _  (Done  refl           k) = Done refl k
-    goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
+    goPeer cs (Yield2 refl m         k) = Yield2 refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
     goPeer cs (YieldAntiPipelined   k) = goSender sender (goPeer cs k)
     goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
@@ -284,7 +284,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
              -> Peer   ps pr 'NonPipelined sst   m a
     goSender  SenderDone             k = k
     goSender (SenderEffect       ks) k = Effect ((`goSender` k) <$> ks)
-    goSender (SenderYield refl m ks) k = Yield refl m (goSender ks k)
+    goSender (SenderYield refl m ks) k = Yield2 refl m (goSender ks k)
 
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
@@ -306,7 +306,7 @@ promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
           Peer ps pr 'NonPipelined            st' m a
        -> Peer ps pr ('AntiPipelined st st 'Z) st' m a
     go (Effect         k) = Effect (go <$> k)
-    go (Yield refl m   k) = Yield refl m (go k)
+    go (Yield2 refl m   k) = Yield2 refl m (go k)
     go (Await refl     k) = Await refl (go . k)
     go (Done  refl     k) = Done refl k
 

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -12,11 +12,16 @@ module Network.TypedProtocol.Proofs
   ( -- * Connect proofs
     connect
   , connectPipelined
+  , connectAntiPipelined
   , TerminalStates (..)
     -- * Pipelining proofs
     -- | Additional proofs specific to the pipelining features
   , forgetPipelined
   , promoteToPipelined
+    -- * Anti-pipelining proofs
+    -- | Additional proofs specific to the anti-pipelining features
+  , forgetAntiPipelined
+  , promoteToAntiPipelined
     -- ** Pipeline proof helpers
   , Queue (..)
   , enqueue
@@ -224,6 +229,99 @@ connectPipelined
     -- ^ peers results and an evidence of their termination
 connectPipelined csA a b =
     connect (forgetPipelined csA a) b
+
+
+--
+-- Remove Anti-Pipelining
+--
+
+
+-- | Proof that we have a total conversion from anti-pipelined peers to regular
+-- peers. This is the anti-pipelining analogue of 'forgetPipelined'.
+--
+-- Where 'forgetPipelined' inlines each deferred 'Receiver' at the point it is
+-- collected, this inlines the single 'Sender' at each 'YieldAntiPipelined':
+-- the messages the sender thread would have sent asynchronously are instead
+-- sent synchronously, at the point the peer delegated them.
+--
+-- Dually to 'forgetPipelined', the @[Bool]@ chooses the interleaving at each
+-- 'AntiCollect': a @True@ pretends the delegated 'Sender' has not terminated
+-- yet, so the peer takes its non-blocking continuation (when it has one) and
+-- leaves the send outstanding; a @False@ (or @[]@) collects.
+--
+forgetAntiPipelined
+  :: forall ps (pr :: PeerRole) (st :: ps) m a.
+     Functor m
+  => [Bool]
+  -- ^ interleaving choices for anti-pipelining allowed by `AntiCollect` primitive.
+  -- False values or `[]` give no anti-pipelining.
+  -> PeerAntiPipelined ps pr              st m a
+  -> Peer              ps pr NonPipelined st m a
+forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m) peer0) =
+    goPeer cs0 peer0
+  where
+    goPeer :: forall st' n.
+              [Bool]
+           -> Peer ps pr ('AntiPipelined apst apst' n) st' m a
+           -> Peer ps pr 'NonPipelined                 st' m a
+    goPeer cs (Effect               k) = Effect (goPeer cs <$> k)
+    goPeer _  (Done  refl           k) = Done refl k
+    goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
+    goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
+    goPeer cs (YieldAntiPipelined _ k) = goSender sender (goPeer cs k)
+    goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
+    goPeer (_:cs)     (AntiCollect k _)        = goPeer cs  k
+    goPeer cs@[]      (AntiCollect k _)        = goPeer cs  k
+
+    goSender :: forall sst.
+                Sender ps pr sst apst' m
+             -> Peer   ps pr 'NonPipelined apst' m a
+             -> Peer   ps pr 'NonPipelined sst   m a
+    goSender  SenderDone               k = k
+    goSender (SenderEffect         ks) k = Effect ((`goSender` k) <$> ks)
+    goSender (SenderYield refl m   ks) k = Yield refl m (goSender ks k)
+
+
+-- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.
+--
+-- This is a right inverse of 'forgetAntiPipelined', e.g.
+--
+-- >>> forgetAntiPipelined . promoteToAntiPipelined = id
+--
+promoteToAntiPipelined
+  :: forall ps (pr :: PeerRole) (st :: ps) m a.
+     Functor m
+  => Peer              ps pr NonPipelined st m a
+  -- ^ a peer
+  -> PeerAntiPipelined ps pr              st m a
+  -- ^ an anti-pipelined peer
+promoteToAntiPipelined p = PeerAntiPipelined SenderDone (go p)
+  where
+    go :: forall st'.
+          Peer ps pr 'NonPipelined            st' m a
+       -> Peer ps pr ('AntiPipelined st st 'Z) st' m a
+    go (Effect         k) = Effect (go <$> k)
+    go (Yield refl m   k) = Yield refl m (go k)
+    go (Await refl     k) = Await refl (go . k)
+    go (Done  refl     k) = Done refl k
+
+
+-- | Analogous to 'connectPipelined' but for anti-pipelined peers.
+--
+connectAntiPipelined
+  :: forall ps (pr :: PeerRole)
+               (st :: ps) m a b.
+       (Monad m, SingI pr)
+    => [Bool]
+    -- ^ an interleaving
+    -> PeerAntiPipelined ps             pr               st m a
+    -- ^ an anti-pipelined peer
+    -> Peer              ps (FlipAgency pr) NonPipelined st m b
+    -- ^ a non-pipelined peer with flipped agency
+    -> m (a, b, TerminalStates ps)
+    -- ^ peers results and an evidence of their termination
+connectAntiPipelined cs a b =
+    connect (forgetAntiPipelined cs a) b
 
 -- | A reference specification for interleaving of requests and responses
 -- with pipelining, where the environment can choose whether a response is

--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -273,7 +273,7 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
     goPeer _  (Done  refl           k) = Done refl k
     goPeer cs (Yield refl m         k) = Yield refl m (goPeer cs k)
     goPeer cs (Await refl           k) = Await refl (goPeer cs . k)
-    goPeer cs (YieldAntiPipelined _ k) = goSender sender (goPeer cs k)
+    goPeer cs (YieldAntiPipelined   k) = goSender sender (goPeer cs k)
     goPeer (True:cs') (AntiCollect _ (Just k)) = goPeer cs' k
     goPeer (_:cs)     (AntiCollect k _)        = goPeer cs  k
     goPeer cs@[]      (AntiCollect k _)        = goPeer cs  k
@@ -282,9 +282,9 @@ forgetAntiPipelined cs0 (PeerAntiPipelined (sender :: Sender ps pr apst apst' m)
                 Sender ps pr sst apst' m
              -> Peer   ps pr 'NonPipelined apst' m a
              -> Peer   ps pr 'NonPipelined sst   m a
-    goSender  SenderDone               k = k
-    goSender (SenderEffect         ks) k = Effect ((`goSender` k) <$> ks)
-    goSender (SenderYield refl m   ks) k = Yield refl m (goSender ks k)
+    goSender  SenderDone             k = k
+    goSender (SenderEffect       ks) k = Effect ((`goSender` k) <$> ks)
+    goSender (SenderYield refl m ks) k = Yield refl m (goSender ks k)
 
 
 -- | Promote a peer to an anti-pipelined one, using an empty 'Sender'.

--- a/typed-protocols/stateful/Network/TypedProtocol/Stateful/Proofs.hs
+++ b/typed-protocols/stateful/Network/TypedProtocol/Stateful/Proofs.hs
@@ -55,7 +55,7 @@ removeState = go
       -> ST.Peer ps pr              st f m a
       ->    Peer ps pr NonPipelined st   m a
     go f (ST.Effect k) = Effect (go f <$> k)
-    go _ (ST.Yield refl _f f' msg k) = Yield2 refl msg (go f' k)
+    go _ (ST.Yield refl _f f' msg k) = Yield refl msg (go f' k)
     go f (ST.Await refl k) = Await refl $ \msg ->
       case k f msg of
         (k', f') -> go f' k'

--- a/typed-protocols/stateful/Network/TypedProtocol/Stateful/Proofs.hs
+++ b/typed-protocols/stateful/Network/TypedProtocol/Stateful/Proofs.hs
@@ -55,7 +55,7 @@ removeState = go
       -> ST.Peer ps pr              st f m a
       ->    Peer ps pr NonPipelined st   m a
     go f (ST.Effect k) = Effect (go f <$> k)
-    go _ (ST.Yield refl _f f' msg k) = Yield refl msg (go f' k)
+    go _ (ST.Yield refl _f f' msg k) = Yield2 refl msg (go f' k)
     go f (ST.Await refl k) = Await refl $ \msg ->
       case k f msg of
         (k', f') -> go f' k'

--- a/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
@@ -58,14 +58,14 @@ tests = testGroup "Network.TypedProtocol.ReqResp"
   , testProperty "directPipelined"     prop_directPipelined
   , testProperty "connect"             prop_connect
   , testProperty "connectPipelined"    prop_connectPipelined
-  , testProperty "connectAntiPipelined" prop_connectAntiPipelined
+  , testProperty "connectDualPipelined" prop_connectDualPipelined
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "channelPipelined ST" prop_channelPipelined_ST
   , testProperty "channelPipelined IO" prop_channelPipelined_IO
-  , testProperty "channelAntiPipelined ST" prop_channelAntiPipelined_ST
-  , testProperty "channelAntiPipelined IO" prop_channelAntiPipelined_IO
-  , testProperty "channelAntiPipelined IOSimPOR" prop_channelAntiPipelined_IOSimPOR
+  , testProperty "channelDualPipelined ST" prop_channelDualPipelined_ST
+  , testProperty "channelDualPipelined IO" prop_channelDualPipelined_IO
+  , testProperty "channelDualPipelined IOSimPOR" prop_channelDualPipelined_IOSimPOR
 #if !defined(mingw32_HOST_OS)
   , testProperty "namedPipePipelined"  prop_namedPipePipelined_IO
   , testProperty "socketPipelined"     prop_socketPipelined_IO
@@ -179,11 +179,11 @@ prop_connectPipelined cs f xs =
 -- ignores the request payload and reads each reply from the state) against a
 -- non-pipelined client. The result must not depend on the interleaving choices.
 --
-prop_connectAntiPipelined :: [Bool] -> (Int -> (Int, Int)) -> NonNegative Int -> Bool
-prop_connectAntiPipelined cs g (NonNegative n) =
+prop_connectDualPipelined :: [Bool] -> (Int -> (Int, Int)) -> NonNegative Int -> Bool
+prop_connectDualPipelined cs g (NonNegative n) =
     case runState
-           (connectAntiPipelined cs
-             (reqRespServerPeerAntiPipelined nextResp)
+           (connectDualPipelined cs
+             (reqRespServerPeerDualPipelined nextResp)
              (reqRespClientPeer (reqRespClientMap (replicate n ()))))
            0
 
@@ -259,15 +259,15 @@ prop_channelPipelined_ST f xs =
                      Right res -> res
 
 
--- | The channel/driver sibling of 'prop_connectAntiPipelined': a pipelined
+-- | The channel/driver sibling of 'prop_connectDualPipelined': a pipelined
 -- client against an anti-pipelined server, run through the real
--- 'runPipelinedPeer' / 'runAntiPipelinedPeer' drivers over a channel. Unlike
+-- 'runPipelinedPeer' / 'runDualPipelinedPeer' drivers over a channel. Unlike
 -- @connect@, this genuinely runs the 'Sender' concurrently with the main peer's
 -- receive-ahead, so the anti-pipelining machinery is actually exercised. The
 -- collected replies must equal the reference sequence regardless of the
 -- interleaving the runtime picks.
 --
-prop_channelAntiPipelined :: ( MonadLabelledSTM m
+prop_channelDualPipelined :: ( MonadLabelledSTM m
                              , MonadAsync m
                              , MonadCatch m
                              , MonadEvaluate m
@@ -276,7 +276,7 @@ prop_channelAntiPipelined :: ( MonadLabelledSTM m
                              )
                           => (Int -> (Int, Int)) -> NonNegative Int
                           -> m Bool
-prop_channelAntiPipelined g (NonNegative n) = do
+prop_channelDualPipelined g (NonNegative n) = do
     -- mark all threads forked from here on as system threads, so IOSimPOR will
     -- reverse races between the client's receiver and the server's 'Sender'
     -- (a no-op under IO / plain IOSim)
@@ -288,21 +288,21 @@ prop_channelAntiPipelined g (NonNegative n) = do
                      writeTVar accVar a'
                      return r
         client   = reqRespClientPeerPipelined (reqRespClientMapPipelined (replicate n ()))
-        server   = reqRespServerPeerAntiPipelined nextResp
-    (resps, ()) <- runConnectedPeersAntiPipelined
+        server   = reqRespServerPeerDualPipelined nextResp
+    (resps, ()) <- runConnectedPeersDualPipelined
                      (createPipelineTestChannels 100)
                      nullTracer
                      CBOR.codecReqResp
                      client server
     return (resps == snd (mapAccumL (\a () -> g a) 0 (replicate n ())))
 
-prop_channelAntiPipelined_IO :: (Int -> (Int, Int)) -> NonNegative Int -> Property
-prop_channelAntiPipelined_IO g n =
-    ioProperty (prop_channelAntiPipelined g n)
+prop_channelDualPipelined_IO :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelDualPipelined_IO g n =
+    ioProperty (prop_channelDualPipelined g n)
 
-prop_channelAntiPipelined_ST :: (Int -> (Int, Int)) -> NonNegative Int -> Property
-prop_channelAntiPipelined_ST g n =
-    let tr = runSimTrace (prop_channelAntiPipelined g n) in
+prop_channelDualPipelined_ST :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelDualPipelined_ST g n =
+    let tr = runSimTrace (prop_channelDualPipelined g n) in
     counterexample (intercalate "\n" $ map show $ traceEvents tr)
                  $ case traceResult True tr of
                      Left  err -> throw err
@@ -314,10 +314,10 @@ prop_channelAntiPipelined_ST g n =
 -- schedule. The request count is kept small so the schedule space stays
 -- tractable.
 --
-prop_channelAntiPipelined_IOSimPOR :: (Int -> (Int, Int)) -> NonNegative Int -> Property
-prop_channelAntiPipelined_IOSimPOR g (NonNegative n) =
+prop_channelDualPipelined_IOSimPOR :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelDualPipelined_IOSimPOR g (NonNegative n) =
     withMaxSuccess 20 $
-    exploreSimTrace id (prop_channelAntiPipelined g (NonNegative (min n 6))) $ \_ tr ->
+    exploreSimTrace id (prop_channelDualPipelined g (NonNegative (min n 6))) $ \_ tr ->
       case traceResult False tr of
         Left  failure -> counterexample (show failure) (property False)
         Right res     -> property res

--- a/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
@@ -58,14 +58,14 @@ tests = testGroup "Network.TypedProtocol.ReqResp"
   , testProperty "directPipelined"     prop_directPipelined
   , testProperty "connect"             prop_connect
   , testProperty "connectPipelined"    prop_connectPipelined
-  , testProperty "connectDualPipelined" prop_connectDualPipelined
+  , testProperty "connectDualPipelined1" prop_connectDualPipelined1
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "channelPipelined ST" prop_channelPipelined_ST
   , testProperty "channelPipelined IO" prop_channelPipelined_IO
-  , testProperty "channelDualPipelined ST" prop_channelDualPipelined_ST
-  , testProperty "channelDualPipelined IO" prop_channelDualPipelined_IO
-  , testProperty "channelDualPipelined IOSimPOR" prop_channelDualPipelined_IOSimPOR
+  , testProperty "channelDualPipelined1 ST" prop_channelDualPipelined1_ST
+  , testProperty "channelDualPipelined1 IO" prop_channelDualPipelined1_IO
+  , testProperty "channelDualPipelined1 IOSimPOR" prop_channelDualPipelined1_IOSimPOR
 #if !defined(mingw32_HOST_OS)
   , testProperty "namedPipePipelined"  prop_namedPipePipelined_IO
   , testProperty "socketPipelined"     prop_socketPipelined_IO
@@ -179,11 +179,11 @@ prop_connectPipelined cs f xs =
 -- ignores the request payload and reads each reply from the state) against a
 -- non-pipelined client. The result must not depend on the interleaving choices.
 --
-prop_connectDualPipelined :: [Bool] -> (Int -> (Int, Int)) -> NonNegative Int -> Bool
-prop_connectDualPipelined cs g (NonNegative n) =
+prop_connectDualPipelined1 :: [Bool] -> (Int -> (Int, Int)) -> NonNegative Int -> Bool
+prop_connectDualPipelined1 cs g (NonNegative n) =
     case runState
-           (connectDualPipelined cs
-             (reqRespServerPeerDualPipelined nextResp)
+           (connectDualPipelined1 cs
+             (reqRespServerPeerDualPipelined1 nextResp)
              (reqRespClientPeer (reqRespClientMap (replicate n ()))))
            0
 
@@ -259,15 +259,15 @@ prop_channelPipelined_ST f xs =
                      Right res -> res
 
 
--- | The channel/driver sibling of 'prop_connectDualPipelined': a pipelined
+-- | The channel/driver sibling of 'prop_connectDualPipelined1': a pipelined
 -- client against an anti-pipelined server, run through the real
--- 'runPipelinedPeer' / 'runDualPipelinedPeer' drivers over a channel. Unlike
+-- 'runPipelinedPeer' / 'runDualPipelined1Peer' drivers over a channel. Unlike
 -- @connect@, this genuinely runs the 'Sender' concurrently with the main peer's
 -- receive-ahead, so the anti-pipelining machinery is actually exercised. The
 -- collected replies must equal the reference sequence regardless of the
 -- interleaving the runtime picks.
 --
-prop_channelDualPipelined :: ( MonadLabelledSTM m
+prop_channelDualPipelined1 :: ( MonadLabelledSTM m
                              , MonadAsync m
                              , MonadCatch m
                              , MonadEvaluate m
@@ -276,7 +276,7 @@ prop_channelDualPipelined :: ( MonadLabelledSTM m
                              )
                           => (Int -> (Int, Int)) -> NonNegative Int
                           -> m Bool
-prop_channelDualPipelined g (NonNegative n) = do
+prop_channelDualPipelined1 g (NonNegative n) = do
     -- mark all threads forked from here on as system threads, so IOSimPOR will
     -- reverse races between the client's receiver and the server's 'Sender'
     -- (a no-op under IO / plain IOSim)
@@ -288,21 +288,21 @@ prop_channelDualPipelined g (NonNegative n) = do
                      writeTVar accVar a'
                      return r
         client   = reqRespClientPeerPipelined (reqRespClientMapPipelined (replicate n ()))
-        server   = reqRespServerPeerDualPipelined nextResp
-    (resps, ()) <- runConnectedPeersDualPipelined
+        server   = reqRespServerPeerDualPipelined1 nextResp
+    (resps, ()) <- runConnectedPeersDualPipelined1
                      (createPipelineTestChannels 100)
                      nullTracer
                      CBOR.codecReqResp
                      client server
     return (resps == snd (mapAccumL (\a () -> g a) 0 (replicate n ())))
 
-prop_channelDualPipelined_IO :: (Int -> (Int, Int)) -> NonNegative Int -> Property
-prop_channelDualPipelined_IO g n =
-    ioProperty (prop_channelDualPipelined g n)
+prop_channelDualPipelined1_IO :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelDualPipelined1_IO g n =
+    ioProperty (prop_channelDualPipelined1 g n)
 
-prop_channelDualPipelined_ST :: (Int -> (Int, Int)) -> NonNegative Int -> Property
-prop_channelDualPipelined_ST g n =
-    let tr = runSimTrace (prop_channelDualPipelined g n) in
+prop_channelDualPipelined1_ST :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelDualPipelined1_ST g n =
+    let tr = runSimTrace (prop_channelDualPipelined1 g n) in
     counterexample (intercalate "\n" $ map show $ traceEvents tr)
                  $ case traceResult True tr of
                      Left  err -> throw err
@@ -314,10 +314,10 @@ prop_channelDualPipelined_ST g n =
 -- schedule. The request count is kept small so the schedule space stays
 -- tractable.
 --
-prop_channelDualPipelined_IOSimPOR :: (Int -> (Int, Int)) -> NonNegative Int -> Property
-prop_channelDualPipelined_IOSimPOR g (NonNegative n) =
+prop_channelDualPipelined1_IOSimPOR :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelDualPipelined1_IOSimPOR g (NonNegative n) =
     withMaxSuccess 20 $
-    exploreSimTrace id (prop_channelDualPipelined g (NonNegative (min n 6))) $ \_ tr ->
+    exploreSimTrace id (prop_channelDualPipelined1 g (NonNegative (min n 6))) $ \_ tr ->
       case traceResult False tr of
         Left  failure -> counterexample (show failure) (property False)
         Right res     -> property res

--- a/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
@@ -18,9 +18,11 @@ import Network.TypedProtocol.ReqResp.Server
 import Network.TypedProtocol.ReqResp.Type
 
 import Control.Exception (throw)
+import Control.Concurrent.Class.MonadSTM.TVar (newTVarIO, readTVar, writeTVar)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadSTM
+import Control.Monad.Class.MonadTest (MonadTest (exploreRaces))
 import Control.Monad.Class.MonadThrow
 import Control.Monad.IOSim
 import Control.Monad.ST (runST)
@@ -63,6 +65,7 @@ tests = testGroup "Network.TypedProtocol.ReqResp"
   , testProperty "channelPipelined IO" prop_channelPipelined_IO
   , testProperty "channelAntiPipelined ST" prop_channelAntiPipelined_ST
   , testProperty "channelAntiPipelined IO" prop_channelAntiPipelined_IO
+  , testProperty "channelAntiPipelined IOSimPOR" prop_channelAntiPipelined_IOSimPOR
 #if !defined(mingw32_HOST_OS)
   , testProperty "namedPipePipelined"  prop_namedPipePipelined_IO
   , testProperty "socketPipelined"     prop_socketPipelined_IO
@@ -304,6 +307,21 @@ prop_channelAntiPipelined_ST g n =
                  $ case traceResult True tr of
                      Left  err -> throw err
                      Right res -> res
+
+-- | The point of the exercise: have IOSimPOR systematically explore the
+-- interleavings of the client's receivers and the server's 'Sender', checking
+-- that the anti-pipelined driver produces the reference result under every
+-- schedule. The request count is kept small so the schedule space stays
+-- tractable.
+--
+prop_channelAntiPipelined_IOSimPOR :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelAntiPipelined_IOSimPOR g (NonNegative n) =
+    withMaxSuccess 20 $
+    exploreSimTrace id (prop_channelAntiPipelined g (NonNegative (min n 6))) $ \_ tr ->
+      case traceResult False tr of
+        Left  failure -> counterexample (show failure) (property False)
+        Right res     -> property res
+
 
 #if !defined(mingw32_HOST_OS)
 prop_namedPipePipelined_IO :: (Int -> Int -> (Int, Int)) -> [Int]

--- a/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/test/Network/TypedProtocol/ReqResp/Tests.hs
@@ -24,6 +24,7 @@ import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadThrow
 import Control.Monad.IOSim
 import Control.Monad.ST (runST)
+import Control.Monad.Trans.State.Strict (State, runState, state)
 import Control.Tracer (nullTracer)
 
 import Data.Functor.Identity (Identity (..))
@@ -55,10 +56,13 @@ tests = testGroup "Network.TypedProtocol.ReqResp"
   , testProperty "directPipelined"     prop_directPipelined
   , testProperty "connect"             prop_connect
   , testProperty "connectPipelined"    prop_connectPipelined
+  , testProperty "connectAntiPipelined" prop_connectAntiPipelined
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "channelPipelined ST" prop_channelPipelined_ST
   , testProperty "channelPipelined IO" prop_channelPipelined_IO
+  , testProperty "channelAntiPipelined ST" prop_channelAntiPipelined_ST
+  , testProperty "channelAntiPipelined IO" prop_channelAntiPipelined_IO
 #if !defined(mingw32_HOST_OS)
   , testProperty "namedPipePipelined"  prop_namedPipePipelined_IO
   , testProperty "socketPipelined"     prop_socketPipelined_IO
@@ -168,6 +172,25 @@ prop_connectPipelined cs f xs =
            (s, c) == mapAccumL f 0 xs
 
 
+-- | The dual of 'prop_connectPipelined': an anti-pipelined server (which
+-- ignores the request payload and reads each reply from the state) against a
+-- non-pipelined client. The result must not depend on the interleaving choices.
+--
+prop_connectAntiPipelined :: [Bool] -> (Int -> (Int, Int)) -> NonNegative Int -> Bool
+prop_connectAntiPipelined cs g (NonNegative n) =
+    case runState
+           (connectAntiPipelined cs
+             (reqRespServerPeerAntiPipelined nextResp)
+             (reqRespClientPeer (reqRespClientMap (replicate n ()))))
+           0
+
+      of ((_, resps, TerminalStates SingDone SingDone), acc) ->
+           (acc, resps) == mapAccumL (\a () -> g a) 0 (replicate n ())
+  where
+    nextResp :: State Int Int
+    nextResp = state (\a -> let (a', r) = g a in (r, a'))
+
+
 --
 -- Properties using channels, codecs and drivers.
 --
@@ -232,6 +255,55 @@ prop_channelPipelined_ST f xs =
                      Left  err -> throw err
                      Right res -> res
 
+
+-- | The channel/driver sibling of 'prop_connectAntiPipelined': a pipelined
+-- client against an anti-pipelined server, run through the real
+-- 'runPipelinedPeer' / 'runAntiPipelinedPeer' drivers over a channel. Unlike
+-- @connect@, this genuinely runs the 'Sender' concurrently with the main peer's
+-- receive-ahead, so the anti-pipelining machinery is actually exercised. The
+-- collected replies must equal the reference sequence regardless of the
+-- interleaving the runtime picks.
+--
+prop_channelAntiPipelined :: ( MonadLabelledSTM m
+                             , MonadAsync m
+                             , MonadCatch m
+                             , MonadEvaluate m
+                             , MonadST m
+                             , MonadTest m
+                             )
+                          => (Int -> (Int, Int)) -> NonNegative Int
+                          -> m Bool
+prop_channelAntiPipelined g (NonNegative n) = do
+    -- mark all threads forked from here on as system threads, so IOSimPOR will
+    -- reverse races between the client's receiver and the server's 'Sender'
+    -- (a no-op under IO / plain IOSim)
+    exploreRaces
+    accVar <- newTVarIO 0
+    let nextResp = atomically $ do
+                     a <- readTVar accVar
+                     let (a', r) = g a
+                     writeTVar accVar a'
+                     return r
+        client   = reqRespClientPeerPipelined (reqRespClientMapPipelined (replicate n ()))
+        server   = reqRespServerPeerAntiPipelined nextResp
+    (resps, ()) <- runConnectedPeersAntiPipelined
+                     (createPipelineTestChannels 100)
+                     nullTracer
+                     CBOR.codecReqResp
+                     client server
+    return (resps == snd (mapAccumL (\a () -> g a) 0 (replicate n ())))
+
+prop_channelAntiPipelined_IO :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelAntiPipelined_IO g n =
+    ioProperty (prop_channelAntiPipelined g n)
+
+prop_channelAntiPipelined_ST :: (Int -> (Int, Int)) -> NonNegative Int -> Property
+prop_channelAntiPipelined_ST g n =
+    let tr = runSimTrace (prop_channelAntiPipelined g n) in
+    counterexample (intercalate "\n" $ map show $ traceEvents tr)
+                 $ case traceResult True tr of
+                     Left  err -> throw err
+                     Right res -> res
 
 #if !defined(mingw32_HOST_OS)
 prop_namedPipePipelined_IO :: (Int -> Int -> (Int, Int)) -> [Int]

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -169,6 +169,7 @@ test-suite test
   build-depends:      base
                     , bytestring
                     , contra-tracer
+                    , transformers
                     , typed-protocols:{typed-protocols,codec-properties,examples}
                     , io-classes:io-classes
                     , io-sim


### PR DESCRIPTION
I'm currently upgrading the LeiosNotify mini protocol in the `leios-prototype` branch of `ouroboros-consensus` be closer to what I've been intended with the design so far.

This PR was the result of me suddenly remembering yesterday that `typed-protocols` doesn't already allow what I had in mind (but I was confident it was feasible).

The key idea: my intention has been for the LeiosNotify server to maintain a buffer of messages it would like to send. The capacity of that buffer should be NumRequestsThatHaveArrived - NumRepliesAlreadySent. If its capacity ever grows beyond some limit, we disconnect: they sent too many requests without waiting for responses.

Implementing that in `typed-protocols` requires letting the `Peer` that has agency receive a message (which can only happen if the other `Peer` is `Pipelined`). In other words, the send can be non-blocking. This is opposite/dual of what `YieldPipelined` already does, in which a receive is non-blocking. Hence `YieldAntiPipelined` etc (but I'd be happy adopt suggestions for a better name).

A few comments:

- I suspect there is a deadlock risk if one peer is `AntiPipelined` and the other is not `Pipelined`. That seems mild enough, though, since that's a pretty severe mistake to have made.
- I suspect a `Peer` could be both `Pipelined` and `AntiPipelined` at the same time. But I don't need that, so I didn't pursue it.
- The "simpler" and more expressive version of this PR would have the `YieldAntiPipelined` ctor carry the `Sender` and the driver would maintain a queue of `Senders` instead of just the counter this PR uses. But I'm anticipating quite big LeiosNotify pipeline depths (and this is on the upstream side, so there can be hundreds of these `AntiPipelined` `Peer`s running), so I instead required that every `Sender` is the same, so that the driver state is merely a counter instead of a queue. (The LeiosNotify client also shares that same large pipelining depth, and it's currently using a queue of `()`. That's not ideal and maybe worth an eventual PR, but it's at least only one per upstream peer (tens), rather than one per downstream peer (hundreds).)

Lastly, an admission: this all turned out roughly how I thought it would. But then it occurred to me that perhaps there's a simpler approach to LeiosNotify. Since we're bounding how many outstanding requests there are, we could just use a normal `NonPipelined` `Peer` for the server, and have its request handler read from a _bounded_ queue that's not allowed to grow beyond that pipelining depth (and that queue basically exists outside of the `Peer` EDSL/driver).

I can only see a couple benefits to `AntiPipelined`.

- With the _bounded_ queue approach, the peer could have sent an arbitrary amount of requests and we might never punish them for it. Those requests would just build up in the "bearer" that the `NonPipelined` `Peer` pulls from whenever it calls `Await`. But suppose we had no responses to send for a while (ie the queue was empty). Then the only thing stopping the downstream peer from filling up that bearer's buffer is a low-level size limit on that buffer itself. Maybe that's tolerable?
- The other benefit is that the back-pressure is more "precise". It's not obvious to me that that's important. But it has an appeal.
    - The only example I've thought of (just now): a syncing node won't send any LeiosNotify requests until it's caught-up/nearly caught-up. But once it does, (the naive/"simple" implementation of) the bounded queue approach will have a queue full of arbitrarily-old notifications to instantly pull from. That seems undesirable, especially since LeiosNotify clients are going to punish peers that send messages that are "too old". So the fact that `AntiPipelined` server `Peer` _automatically_ has a queue capacity of 0 before any requests arrive is quite preferable---this is "precision" that it seems nice to be able to take for granted.